### PR TITLE
[13.0][IMP] hr_expense_advance_clearing : check clearing on expense

### DIFF
--- a/hr_expense_advance_clearing/models/hr_expense.py
+++ b/hr_expense_advance_clearing/models/hr_expense.py
@@ -9,6 +9,7 @@ class HrExpense(models.Model):
     _inherit = "hr.expense"
 
     advance = fields.Boolean(string="Employee Advance", default=False)
+    clearing = fields.Boolean(default=False)
 
     @api.constrains("advance")
     def _check_advance(self):

--- a/hr_expense_advance_clearing/views/hr_expense_views.xml
+++ b/hr_expense_advance_clearing/views/hr_expense_views.xml
@@ -47,8 +47,14 @@
         <field name="inherit_id" ref="hr_expense.hr_expense_view_form" />
         <field name="arch" type="xml">
             <h1 position="after">
-                <field name="advance" />
-                <label for="advance" />
+                <div attrs="{'invisible': [('clearing', '=', True)]}">
+                    <field name="advance" />
+                    <label for="advance" />
+                </div>
+                <div attrs="{'invisible': [('advance', '=', True)]}">
+                    <field name="clearing" />
+                    <label for="clearing" />
+                </div>
             </h1>
             <field name="analytic_account_id" position="attributes">
                 <attribute
@@ -91,12 +97,20 @@
                     attrs="{'invisible': [('advance', '=', False)]}"
                 />
                 <label for="advance" attrs="{'invisible': [('advance', '=', False)]}" />
+                <field
+                    name="clearing"
+                    attrs="{'invisible': [('clearing', '=', False)]}"
+                />
+                <label
+                    for="clearing"
+                    attrs="{'invisible': [('clearing', '=', False)]}"
+                />
             </h1>
             <xpath expr="/form/sheet/group/group" position="after">
                 <group>
                     <field
                         name="advance_sheet_id"
-                        attrs="{'invisible': [('advance', '=', True)]}"
+                        attrs="{'invisible': [('advance', '=', True)], 'required': [('clearing', '=', True)]}"
                     />
                     <field
                         name="clearing_residual"


### PR DESCRIPTION
- Add clearing on Expense.
- Check clearing on expense that you would clearing advance, it will required field `Clear Advance` on Expense Sheet.
- It will check clearing (if not advance and not clearing) on state Sumbit to Manager.


![Selection_004](https://user-images.githubusercontent.com/20896369/104579164-346f8280-568e-11eb-8c54-18731210cd09.png)
![Selection_005](https://user-images.githubusercontent.com/20896369/104579319-67197b00-568e-11eb-9388-bdd6fa542ee3.png)


cc: @kittiu 
