### PR TITLE
[13.0][IMP+FIX] hr_expense_invoice: Add button to create invoice from expenses + Allow create invoice from invoice_id field

### DIFF
--- a/hr_expense_invoice/models/account_move.py
+++ b/hr_expense_invoice/models/account_move.py
@@ -1,10 +1,31 @@
 # Copyright 2019 Ecosoft <saranl@ecosoft.co.th>
+# Copyright 2021 Tecnativa - Víctor Martínez
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
-from odoo import models
+from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
+from odoo.tools import float_compare
 
 
 class AccountMove(models.Model):
     _inherit = "account.move"
+
+    expense_ids = fields.One2many(
+        comodel_name="hr.expense", inverse_name="invoice_id", string="Expenses"
+    )
+
+    @api.constrains("amount_total")
+    def _check_expense_ids(self):
+        for move in self.filtered("expense_ids"):
+            DecimalPrecision = self.env["decimal.precision"]
+            precision = DecimalPrecision.precision_get("Product Price")
+            expense_amount = sum(move.expense_ids.mapped("total_amount"))
+            if float_compare(expense_amount, move.amount_total, precision) != 0:
+                raise ValidationError(
+                    _(
+                        "You can't change the total amount, as there's an expense "
+                        "linked to this invoice."
+                    )
+                )
 
     def _get_cash_basis_matched_percentage(self):
         res = super()._get_cash_basis_matched_percentage()

--- a/hr_expense_invoice/models/hr_expense.py
+++ b/hr_expense_invoice/models/hr_expense.py
@@ -19,6 +19,7 @@ class HrExpense(models.Model):
             ("type", "=", "in_invoice"),
             ("state", "=", "posted"),
             ("invoice_payment_state", "=", "not_paid"),
+            ("expense_ids", "=", False),
         ],
         copy=False,
     )
@@ -95,5 +96,7 @@ class HrExpense(models.Model):
         """
         if self.invoice_id:
             self.quantity = 1
-            self.unit_amount = self.invoice_id.amount_total
             self.tax_ids = [(5,)]
+            # Assign this amount after removing taxes for avoiding to raise
+            # the constraint _check_expense_ids
+            self.unit_amount = self.invoice_id.amount_total

--- a/hr_expense_invoice/models/hr_expense.py
+++ b/hr_expense_invoice/models/hr_expense.py
@@ -11,7 +11,7 @@ from odoo.exceptions import UserError
 class HrExpense(models.Model):
     _inherit = "hr.expense"
 
-    sheet_id_state = fields.Selection(related="sheet_id.state")
+    sheet_id_state = fields.Selection(related="sheet_id.state", string="Sheet state")
     invoice_id = fields.Many2one(
         comodel_name="account.move",
         string="Vendor Bill",
@@ -44,7 +44,6 @@ class HrExpense(models.Model):
             .with_context(default_type="in_invoice")
             .create(
                 {
-                    "type": "in_invoice",
                     "ref": self.reference,
                     "invoice_date": self.date,
                     "invoice_line_ids": invoice_lines,

--- a/hr_expense_invoice/models/hr_expense.py
+++ b/hr_expense_invoice/models/hr_expense.py
@@ -1,6 +1,7 @@
 # Copyright 2015-2020 Tecnativa - Pedro M. Baeza
 # Copyright 2017 Tecnativa - Vicent Cubells
 # Copyright 2020 Tecnativa - David Vidal
+# Copyright 2021 Tecnativa - Víctor Martínez
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from odoo import _, api, fields, models
@@ -10,6 +11,7 @@ from odoo.exceptions import UserError
 class HrExpense(models.Model):
     _inherit = "hr.expense"
 
+    sheet_id_state = fields.Selection(related="sheet_id.state")
     invoice_id = fields.Many2one(
         comodel_name="account.move",
         string="Vendor Bill",
@@ -20,6 +22,44 @@ class HrExpense(models.Model):
         ],
         copy=False,
     )
+
+    def action_expense_create_invoice(self):
+        invoice_lines = [
+            (
+                0,
+                0,
+                {
+                    "product_id": self.product_id.id,
+                    "name": self.name,
+                    "price_unit": self.unit_amount,
+                    "quantity": self.quantity,
+                    "account_id": self.account_id.id,
+                    "analytic_account_id": self.analytic_account_id.id,
+                    "tax_ids": [(6, 0, self.tax_ids.ids)],
+                },
+            )
+        ]
+        invoice = (
+            self.env["account.move"]
+            .with_context(default_type="in_invoice")
+            .create(
+                {
+                    "type": "in_invoice",
+                    "ref": self.reference,
+                    "invoice_date": self.date,
+                    "invoice_line_ids": invoice_lines,
+                }
+            )
+        )
+        self.write(
+            {
+                "invoice_id": invoice.id,
+                "quantity": 1,
+                "tax_ids": False,
+                "unit_amount": invoice.amount_total,
+            }
+        )
+        return True
 
     @api.constrains("invoice_id")
     def _check_invoice_id(self):

--- a/hr_expense_invoice/tests/test_hr_expense_invoice.py
+++ b/hr_expense_invoice/tests/test_hr_expense_invoice.py
@@ -232,6 +232,39 @@ class TestHrExpenseInvoice(common.SavepointCase):
         # We make payment on expense sheet
         self._register_payment(self.sheet)
 
+    def test_3_hr_test_expense_create_invoice(self):
+        # There is no expense lines in sheet
+        self.assertEqual(len(self.sheet.expense_line_ids), 0)
+        # We add 2 expenses
+        self.sheet.expense_line_ids = [(6, 0, [self.expense.id, self.expense2.id])]
+        self.sheet.approve_expense_sheets()
+        self.assertEqual(len(self.sheet.expense_line_ids), 2)
+        self.expense.action_expense_create_invoice()
+        self.assertTrue(self.expense.invoice_id)
+        self.assertEqual(self.sheet.invoice_count, 1)
+        self.sheet.invalidate_cache()
+        self.expense2.action_expense_create_invoice()
+        self.assertTrue(self.expense2.invoice_id)
+        self.assertEqual(self.sheet.invoice_count, 2)
+        # Validate invoices
+        self.expense.invoice_id.partner_id = self.partner
+        self.expense.invoice_id.action_post()
+        self.expense2.invoice_id.partner_id = self.partner
+        self.expense2.invoice_id.action_post()
+        self.sheet.with_context(
+            {"default_expense_line_ids": self.expense.id}
+        ).action_sheet_move_create()
+        self.assertEqual(self.sheet.state, "post")
+        self.assertTrue(self.sheet.account_move_id)
+        # Invoice are now paid
+        self.assertEqual(self.expense.invoice_id.state, "posted")
+        self.assertEqual(self.expense2.invoice_id.state, "posted")
+        # We make payment on expense sheet
+        self._register_payment(self.sheet)
+        # Click on View Invoice button link to the correct invoice
+        res = self.sheet.action_view_invoices()
+        self.assertEqual(res["view_mode"], "tree,form")
+
     def test_4_hr_expense_constraint(self):
         # Only invoice with status open is allowed
         with self.assertRaises(UserError):

--- a/hr_expense_invoice/tests/test_hr_expense_invoice.py
+++ b/hr_expense_invoice/tests/test_hr_expense_invoice.py
@@ -246,6 +246,16 @@ class TestHrExpenseInvoice(common.SavepointCase):
         self.expense2.action_expense_create_invoice()
         self.assertTrue(self.expense2.invoice_id)
         self.assertEqual(self.sheet.invoice_count, 2)
+        # Only change invoice not assigned to expense yet
+        with self.assertRaises(ValidationError):
+            self.expense.invoice_id.amount_total = 60
+        # Force to change
+        invoice = self.expense2.invoice_id
+        self.expense2.invoice_id = False
+        invoice.amount_total = 50
+        self.assertEqual(self.expense2.total_amount, 50)
+        # Set invoice_id again to expense2
+        self.expense2.invoice_id = invoice
         # Validate invoices
         self.expense.invoice_id.partner_id = self.partner
         self.expense.invoice_id.action_post()
@@ -270,6 +280,7 @@ class TestHrExpenseInvoice(common.SavepointCase):
         # We add an expense, total_amount now = 50.0
         self.sheet.expense_line_ids = [(6, 0, [self.expense.id])]
         # We add invoice to expense
+        self.invoice.amount_total = 100
         self.invoice.action_post()  # residual = 100.0
         self.expense.invoice_id = self.invoice
         # Amount must equal, expense vs invoice

--- a/hr_expense_invoice/tests/test_hr_expense_invoice.py
+++ b/hr_expense_invoice/tests/test_hr_expense_invoice.py
@@ -251,9 +251,7 @@ class TestHrExpenseInvoice(common.SavepointCase):
         self.expense.invoice_id.action_post()
         self.expense2.invoice_id.partner_id = self.partner
         self.expense2.invoice_id.action_post()
-        self.sheet.with_context(
-            {"default_expense_line_ids": self.expense.id}
-        ).action_sheet_move_create()
+        self.sheet.action_sheet_move_create()
         self.assertEqual(self.sheet.state, "post")
         self.assertTrue(self.sheet.account_move_id)
         # Invoice are now paid

--- a/hr_expense_invoice/views/hr_expense_views.xml
+++ b/hr_expense_invoice/views/hr_expense_views.xml
@@ -5,15 +5,24 @@
         <field name="inherit_id" ref="hr_expense.hr_expense_view_form" />
         <field name="groups_id" eval="[(4, ref('account.group_account_invoice'))]" />
         <field name="arch" type="xml">
+            <field name="unit_amount" position="attributes">
+                <attribute name="force_save">1</attribute>
+            </field>
+            <field name="quantity" position="attributes">
+                <attribute name="force_save">1</attribute>
+                <attribute
+                    name="attrs"
+                >{'invisible': [('invoice_id', '!=', False)]}</attribute>
+            </field>
             <field name="product_id" position="after">
                 <field
                     name="invoice_id"
                     context="{'default_type': 'in_invoice',
                             'type': 'in_invoice',
                             'journal_type': 'purchase',
-                            'default_reference': reference,
-                            'default_date_invoice': date,
-                            'default_invoice_line_ids': [{'product_id': product_id,
+                            'default_ref': reference,
+                            'default_invoice_date': date,
+                            'default_line_ids': [{'product_id': product_id,
                                                           'name': name,
                                                           'price_unit': unit_amount,
                                                           'quantity': quantity,

--- a/hr_expense_invoice/views/hr_expense_views.xml
+++ b/hr_expense_invoice/views/hr_expense_views.xml
@@ -41,6 +41,18 @@
             >
                 <field name="invoice_id" />
             </xpath>
+            <xpath
+                expr="//field[@name='expense_line_ids']/tree/field[@name='total_amount']"
+                position="after"
+            >
+                <field name="sheet_id_state" invisible="1" />
+                <button
+                    name="action_expense_create_invoice"
+                    string="Create Vendor Bill"
+                    type="object"
+                    attrs="{'invisible': ['|', ('invoice_id', '!=', False),('sheet_id_state', '!=', 'approve')]}"
+                />
+            </xpath>
             <div class="oe_button_box" position="inside">
                 <button
                     class="oe_stat_button"

--- a/hr_expense_invoice/views/hr_expense_views.xml
+++ b/hr_expense_invoice/views/hr_expense_views.xml
@@ -59,7 +59,7 @@
                     name="action_expense_create_invoice"
                     string="Create Vendor Bill"
                     type="object"
-                    attrs="{'invisible': ['|', ('invoice_id', '!=', False),('sheet_id_state', '!=', 'approve')]}"
+                    attrs="{'invisible': ['|', ('invoice_id', '!=', False),('sheet_id_state', 'not in', ('draft','approve'))]}"
                 />
             </xpath>
             <div class="oe_button_box" position="inside">

--- a/hr_expense_invoice/views/hr_expense_views.xml
+++ b/hr_expense_invoice/views/hr_expense_views.xml
@@ -49,6 +49,7 @@
                 position="after"
             >
                 <field name="invoice_id" />
+                <field name="quantity" invisible="1" />
             </xpath>
             <xpath
                 expr="//field[@name='expense_line_ids']/tree/field[@name='total_amount']"


### PR DESCRIPTION
[IMP] Add button to create invoice from expenses.
[FIX] Allow create invoice from invoice_id field

In these PR https://github.com/OCA/hr-expense/pull/32 we remove it option to create invoice from some expenses but it's a interesting functionallity and with these change add button in expense to allow create invoice with only 1 line.

Please @pedrobaeza and @joao-p-marques can you review it?

@Tecnativa TT29072