### PR TITLE
[14.0][FIX] hr_expense_analytic_distribution, warning message when start from expense report

### DIFF
--- a/hr_expense_analytic_distribution/models/hr_expense_sheet.py
+++ b/hr_expense_analytic_distribution/models/hr_expense_sheet.py
@@ -14,7 +14,7 @@ class HrExpenseSheetInherit(models.Model):
 
     @api.constrains("expense_distribution_ids")
     def _constrains_distribution_ids_percentage(self):
-        for report in self:
+        for report in self.filtered("expense_distribution_ids"):
             total_percent = sum(report.expense_distribution_ids.mapped("percentage"))
             if total_percent != 100:
                 raise UserError(_("Sorry, Percentage should be equal to 100."))


### PR DESCRIPTION
When create Expense Report and then add Expense Line, always get this warning although nothing related with analytic yet.

cc @dreispt @chetanrdhaduk 

![Selection_399](https://user-images.githubusercontent.com/1973598/121784262-373eb700-cbdd-11eb-9b18-ed24968b614b.png)
