### PR TITLE
[14.0][IMP] hr_expense_advance_clearing, allow predefined clearing product

### DIFF
--- a/hr_expense_advance_clearing/models/hr_expense.py
+++ b/hr_expense_advance_clearing/models/hr_expense.py
@@ -9,6 +9,22 @@ class HrExpense(models.Model):
     _inherit = "hr.expense"
 
     advance = fields.Boolean(string="Employee Advance", default=False)
+    clearing_product_id = fields.Many2one(
+        comodel_name="product.product",
+        string="Clearing Product",
+        tracking=True,
+        domain="[('can_be_expensed', '=', True),"
+        "'|', ('company_id', '=', False), ('company_id', '=', company_id)]",
+        ondelete="restrict",
+        help="Optional: On the clear advance, the clearing "
+        "product will create default product line.",
+    )
+    av_line_id = fields.Many2one(
+        comodel_name="hr.expense",
+        string="Ref: Advance",
+        ondelete="set null",
+        help="Expense created from this advance expense line",
+    )
 
     @api.constrains("advance")
     def _check_advance(self):
@@ -40,6 +56,7 @@ class HrExpense(models.Model):
             )
         else:
             self.product_id = False
+            self.clearing_product_id = False
 
     def _get_account_move_line_values(self):
         move_line_values_by_expense = super()._get_account_move_line_values()

--- a/hr_expense_advance_clearing/readme/USAGE.rst
+++ b/hr_expense_advance_clearing/readme/USAGE.rst
@@ -3,6 +3,7 @@
 #. Go to Expenses > My Expenses > My Expenses to Report
 #. Create a new Expense as normal, but also check "Employee Advance" checkbox
 #. Product = Employee Advance will be set automatically, do not change.
+#. As an option, user can also set the "Clearing Product". If this is set, on the clear advance step, the clearing product will create a default product line.
 #. Set the unit price to advance amount
 #. Click Create Report as normal. Please note that, this expense report will also has flag "Employee Advance" checked.
 #. As normal, do Approve > Post Journal Entries > Register Payment.

--- a/hr_expense_advance_clearing/tests/test_hr_expense_advance_clearing.py
+++ b/hr_expense_advance_clearing/tests/test_hr_expense_advance_clearing.py
@@ -79,7 +79,8 @@ class TestHrExpenseAdvanceClearing(common.SavepointCase):
             expense.advance = advance
             expense.name = description
             expense.employee_id = employee
-            expense.product_id = product
+            if not advance:
+                expense.product_id = product
             expense.unit_amount = amount
             expense.payment_mode = payment_mode
         expense = expense.save()
@@ -127,11 +128,6 @@ class TestHrExpenseAdvanceClearing(common.SavepointCase):
                 "Buy service 1,000", self.employee, self.product, 1.0
             )
             self.advance.write({"expense_line_ids": [(4, expense.id)]})
-        # Advance Expense's product must be employee advance
-        with self.assertRaises(ValidationError):
-            expense = self._create_expense(
-                "Advance 1,000", self.employee, self.product, 1.0, advance=True
-            )
         # Advance Expense's product, must not has tax involved
         with self.assertRaises(ValidationError):
             self.emp_advance.supplier_taxes_id |= self.tax

--- a/hr_expense_advance_clearing/views/hr_expense_views.xml
+++ b/hr_expense_advance_clearing/views/hr_expense_views.xml
@@ -50,6 +50,19 @@
                 <field name="advance" />
                 <label for="advance" />
             </h1>
+            <field name="product_id" position="attributes">
+                <attribute
+                    name="attrs"
+                >{'readonly': [('advance', '=', True)]}</attribute>
+                <attribute name="force_save">1</attribute>
+            </field>
+            <field name="product_id" position="after">
+                <field
+                    name="clearing_product_id"
+                    attrs="{'invisible': [('advance', '=', False)]}"
+                    placeholder="Optional clearing product is used during clear advance"
+                />
+            </field>
             <field name="analytic_account_id" position="attributes">
                 <attribute name="attrs">
                     {'invisible': [('advance', '!=', False)]}
@@ -109,11 +122,23 @@
                 </group>
             </xpath>
             <xpath
-                expr="//field[@name='expense_line_ids']/tree/field['name']"
-                position="before"
+                expr="//field[@name='expense_line_ids']/tree/field[@name='name']"
+                position="after"
             >
                 <field name="advance" invisible="1" />
                 <field name="product_id" invisible="1" />
+                <field name="product_uom_id" invisible="1" />
+                <field name="product_uom_category_id" invisible="1" />
+                <field
+                    name="clearing_product_id"
+                    attrs="{'column_invisible': [('advance', '=', False)]}"
+                />
+                <field name="av_line_id" invisible="1" />
+            </xpath>
+            <xpath expr="//field[@name='expense_line_ids']" position="attributes">
+                <attribute
+                    name="context"
+                >{'default_advance': advance, 'form_view_ref' : 'hr_expense.hr_expense_view_form_without_header', 'default_company_id': company_id, 'default_employee_id': employee_id}</attribute>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
This improvement do 2 things,

* Allow multiple advance line.
* Each advance line, can have a default product for clearing.

If clearing product is specified. When user clear advance, they will appear as default expenses.

![image](https://user-images.githubusercontent.com/1973598/121809645-d324fd00-cc87-11eb-9666-2d8fcb19ba5d.png)

TODO:

- [ ] https://github.com/OCA/hr-expense/issues/44