### PR TITLE
[FIX] hr_expense_advance_clearing: default_get return advance

### DIFF
--- a/hr_expense_advance_clearing/tests/test_hr_expense_advance_clearing.py
+++ b/hr_expense_advance_clearing/tests/test_hr_expense_advance_clearing.py
@@ -1,6 +1,7 @@
 # Copyright 2019 Kitti Upariphutthiphong <kittiu@ecosoft.co.th>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+from odoo import fields
 from odoo.exceptions import ValidationError
 from odoo.tests import common
 from odoo.tests.common import Form
@@ -111,6 +112,7 @@ class TestHrExpenseAdvanceClearing(common.SavepointCase):
         PaymentWizard = self.env["account.payment.register"]
         with Form(PaymentWizard.with_context(ctx)) as f:
             f.journal_id = self.journal_bank
+            f.payment_date = fields.Date.today()
         payment_wizard = f.save()
         payment_wizard.action_create_payments()
 


### PR DESCRIPTION
fix from issue https://github.com/OCA/hr-expense/issues/44

In v14 odoo merged register payment wizard on expense into account.payment.register and check some condition
So, expense return advance can't use register payment wizard.

I check context and override default_get on wizard, if it from return advance only.

cc: @kittiu 