### PR TITLE
[14.0][IMP] hr_expense_advance_clearing add tab clearing

### DIFF
--- a/hr_expense_advance_clearing/models/hr_expense_sheet.py
+++ b/hr_expense_advance_clearing/models/hr_expense_sheet.py
@@ -26,6 +26,13 @@ class HrExpenseSheet(models.Model):
         },
         help="Show remaining advance of this employee",
     )
+    clearing_sheet_ids = fields.One2many(
+        comodel_name="hr.expense.sheet",
+        inverse_name="advance_sheet_id",
+        string="Clearing Sheet",
+        readonly=True,
+        help="Show reference clearing on advance",
+    )
     clearing_residual = fields.Monetary(
         string="Amount to clear",
         compute="_compute_clearing_residual",

--- a/hr_expense_advance_clearing/views/hr_expense_views.xml
+++ b/hr_expense_advance_clearing/views/hr_expense_views.xml
@@ -131,7 +131,7 @@
                 <field name="product_uom_category_id" invisible="1" />
                 <field
                     name="clearing_product_id"
-                    attrs="{'column_invisible': [('advance', '=', False)]}"
+                    attrs="{'column_invisible': [('parent.advance', '=', False)]}"
                 />
                 <field name="av_line_id" invisible="1" />
             </xpath>
@@ -139,6 +139,15 @@
                 <attribute
                     name="context"
                 >{'default_advance': advance, 'form_view_ref' : 'hr_expense.hr_expense_view_form_without_header', 'default_company_id': company_id, 'default_employee_id': employee_id}</attribute>
+            </xpath>
+            <xpath expr="//notebook/page[@name='expenses']" position="after">
+                <page
+                    name="clearing"
+                    string="Clearing"
+                    attrs="{'invisible': [('advance', '=', False)]}"
+                >
+                    <field name="clearing_sheet_ids" />
+                </page>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
This PR implement new tab `clearing` for show details sheet clearing on this advance

**Example**
1 Advance but we clearing 3
User don't know, how many document clearing for this advance.

![Selection_004](https://user-images.githubusercontent.com/20896369/126286928-71fecabc-3768-4826-83be-9844d60116ab.png)


This module cherry pick from https://github.com/OCA/hr-expense/pull/45