### PR TITLE
[14.0][IMP] hr_expense_advance_clearing, add invisible fields

### DIFF
--- a/hr_expense_advance_clearing/views/hr_expense_views.xml
+++ b/hr_expense_advance_clearing/views/hr_expense_views.xml
@@ -108,6 +108,13 @@
                     />
                 </group>
             </xpath>
+            <xpath
+                expr="//field[@name='expense_line_ids']/tree/field['name']"
+                position="before"
+            >
+                <field name="advance" invisible="1" />
+                <field name="product_id" invisible="1" />
+            </xpath>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
Add fields as invisible, this is not a harmful change, but can be useful when we pass default context of these field.
* advance
* product_id

@Saran440 can you FFW please.