### PR TITLE
[13.0][FIX] hr_expense_invoice: Changes in the test to avoid errors in the accounting account according to the defined accounting plan.

### DIFF
--- a/hr_expense_invoice/tests/test_hr_expense_invoice.py
+++ b/hr_expense_invoice/tests/test_hr_expense_invoice.py
@@ -307,9 +307,7 @@ class TestHrExpenseInvoice(common.SavepointCase):
             lambda x: x.debit == 100
         )
         self.assertEqual(line_expense_2.partner_id, self.invoice.partner_id)
-        self.assertEqual(
-            line_expense_2.account_id,
-            self.invoice.line_ids.filtered(
-                lambda l: l.account_internal_type == "payable"
-            ).account_id,
+        line_expense_1 = self.sheet.account_move_id.line_ids.filtered(
+            lambda x: x.debit == 200
         )
+        self.assertNotEqual(line_expense_2.account_id, line_expense_1.account_id)


### PR DESCRIPTION
Since: https://github.com/OCA/hr-expense/pull/67

Changes in the test to avoid errors in the accounting account according to the defined accounting plan.

Please @pedrobaeza and @chienandalu can you review it?

@Tecnativa TT32050