### PR TITLE
[14.0][IMP] hr_expense_advance_clearing, add menus Advance/Expense

### DIFF
--- a/hr_expense_advance_clearing/models/hr_expense.py
+++ b/hr_expense_advance_clearing/models/hr_expense.py
@@ -54,9 +54,6 @@ class HrExpense(models.Model):
             self.product_id = self.env.ref(
                 "hr_expense_advance_clearing.product_emp_advance"
             )
-        else:
-            self.product_id = False
-            self.clearing_product_id = False
 
     def _get_account_move_line_values(self):
         move_line_values_by_expense = super()._get_account_move_line_values()

--- a/hr_expense_advance_clearing/models/hr_expense_sheet.py
+++ b/hr_expense_advance_clearing/models/hr_expense_sheet.py
@@ -54,8 +54,10 @@ class HrExpenseSheet(models.Model):
     @api.depends("expense_line_ids")
     def _compute_advance(self):
         for sheet in self:
-            sheet.advance = sheet.expense_line_ids and all(
-                sheet.expense_line_ids.mapped("advance")
+            sheet.advance = (
+                sheet.expense_line_ids
+                and all(sheet.expense_line_ids.mapped("advance"))
+                or self.env.context.get("default_advance")
             )
         return
 

--- a/hr_expense_advance_clearing/tests/test_hr_expense_advance_clearing.py
+++ b/hr_expense_advance_clearing/tests/test_hr_expense_advance_clearing.py
@@ -75,8 +75,9 @@ class TestHrExpenseAdvanceClearing(common.SavepointCase):
         advance=False,
         payment_mode="own_account",
     ):
-        with Form(self.env["hr.expense"]) as expense:
-            expense.advance = advance
+        with Form(
+            self.env["hr.expense"].with_context(default_advance=advance)
+        ) as expense:
             expense.name = description
             expense.employee_id = employee
             if not advance:

--- a/hr_expense_advance_clearing/views/hr_expense_views.xml
+++ b/hr_expense_advance_clearing/views/hr_expense_views.xml
@@ -1,5 +1,78 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <odoo>
+
+    <!-- New menus Advance and Expense under My Reports -->
+
+    <record id="action_my_hr_advance_sheet" model="ir.actions.act_window">
+        <field name="name">Advances</field>
+        <field name="res_model">hr.expense.sheet</field>
+        <field name="view_mode">tree,kanban,form,pivot,graph,activity</field>
+        <field name="search_view_id" ref="hr_expense.hr_expense_sheet_view_search" />
+        <field name="domain">[('state', '!=', 'cancel'), ('advance', '=', True)]</field>
+        <field
+            name="context"
+        >{'search_default_my_reports': 1, 'default_advance': True}</field>
+        <field name="help" type="html">
+            <p class="o_view_nocontent_smiling_face">
+            No advance report found. Let's create one!
+            </p><p>
+            Once you have created your advance, submit it to your manager who will validate it.
+            </p>
+        </field>
+    </record>
+    <record id="action_my_hr_expense_sheet" model="ir.actions.act_window">
+        <field name="name">Expenses</field>
+        <field name="res_model">hr.expense.sheet</field>
+        <field name="view_mode">tree,kanban,form,pivot,graph,activity</field>
+        <field name="search_view_id" ref="hr_expense.hr_expense_sheet_view_search" />
+        <field
+            name="domain"
+        >[('state', '!=', 'cancel'), ('advance', '=', False)]</field>
+        <field name="context">{'search_default_my_reports': 1}</field>
+        <field name="help" type="html">
+            <p class="o_view_nocontent_smiling_face">
+            No expense report found. Let's create one!
+            </p><p>
+            Once you have created your expense, submit it to your manager who will validate it.
+            </p>
+        </field>
+    </record>
+    <menuitem
+        id="menu_my_hr_advance_sheet"
+        sequence="1"
+        parent="hr_expense.menu_hr_expense_sheet_my_reports"
+        action="action_my_hr_advance_sheet"
+        name="Advances"
+    />
+    <menuitem
+        id="menu_my_hr_expense_sheet"
+        sequence="2"
+        parent="hr_expense.menu_hr_expense_sheet_my_reports"
+        action="action_my_hr_expense_sheet"
+        name="Expenses"
+    />
+
+    <!-- End new menus -->
+
+    <record id="hr_expense_view_search" model="ir.ui.view">
+        <field name="name">hr.expense.view.search</field>
+        <field name="model">hr.expense</field>
+        <field name="inherit_id" ref="hr_expense.hr_expense_view_search" />
+        <field name="arch" type="xml">
+            <separator position="after">
+                <filter
+                    string="Advance"
+                    name="is_advance"
+                    domain="[('advance', '=', True)]"
+                />
+                <filter
+                    string="Expense"
+                    name="is_expense"
+                    domain="[('advance', '=', False)]"
+                />
+            </separator>
+        </field>
+    </record>
     <record id="hr_expense_sheet_view_search" model="ir.ui.view">
         <field name="name">hr.expense.sheet.view.search</field>
         <field name="model">hr.expense.sheet</field>
@@ -47,8 +120,13 @@
         <field name="inherit_id" ref="hr_expense.hr_expense_view_form" />
         <field name="arch" type="xml">
             <h1 position="after">
-                <field name="advance" />
-                <label for="advance" />
+                <field
+                    name="advance"
+                    invisible="not context.get('default_advance')"
+                    readonly="1"
+                    force_save="1"
+                />
+                <label for="advance" invisible="not context.get('default_advance')" />
             </h1>
             <field name="product_id" position="attributes">
                 <attribute
@@ -150,7 +228,7 @@
             <xpath expr="//field[@name='expense_line_ids']" position="attributes">
                 <attribute
                     name="context"
-                >{'default_advance': advance, 'form_view_ref' : 'hr_expense.hr_expense_view_form_without_header', 'default_company_id': company_id, 'default_employee_id': employee_id}</attribute>
+                >{'default_advance': advance, 'search_default_is_advance': advance, 'search_default_is_expense': not advance, 'form_view_ref' : 'hr_expense.hr_expense_view_form_without_header', 'default_company_id': company_id, 'default_employee_id': employee_id}</attribute>
             </xpath>
             <xpath expr="//notebook/page[@name='expenses']" position="after">
                 <page


### PR DESCRIPTION
This PR enhance the menu / view, to split Advance menu. This is to improve usability and less confuse user.

This module will ensure that, if user want to use Advance, he/she will start from Advance menu.

![Selection_184](https://user-images.githubusercontent.com/1973598/139788215-ccb54120-7b2d-4712-a3b3-c5b8d02fdfbd.png)

On create Advance Sheet, it will default check "Advance"

![Selection_185](https://user-images.githubusercontent.com/1973598/139788223-a0564d5a-ec8d-4ccf-9598-37e7768bee0c.png)

And when create lines, it will also auto check "Advance"

![Selection_186](https://user-images.githubusercontent.com/1973598/139788231-61a282c4-b05a-4c14-b4e2-79978e4ff2ea.png)

