### PR TITLE
[14.0][FIX] hr_expense_advance_clearing: constrains with advance clearing

### DIFF
--- a/hr_expense_advance_clearing/models/hr_expense.py
+++ b/hr_expense_advance_clearing/models/hr_expense.py
@@ -40,6 +40,10 @@ class HrExpense(models.Model):
                 raise ValidationError(
                     _("Employee advance, selected product is not valid")
                 )
+            if expense.account_id != emp_advance.property_account_expense_id:
+                raise ValidationError(
+                    _("Employee advance, account must be the same payable account")
+                )
             if expense.tax_ids:
                 raise ValidationError(_("Employee advance, all taxes must be removed"))
             if expense.payment_mode != "own_account":

--- a/hr_expense_advance_clearing/wizard/account_payment_register.py
+++ b/hr_expense_advance_clearing/wizard/account_payment_register.py
@@ -123,7 +123,7 @@ class AccountPaymentRegister(models.TransientModel):
         # i.e. lookup on the advance account on move lines
         account_move_lines_to_reconcile = self.env["account.move.line"]
         for line in payment.move_id.line_ids + expense_sheet.account_move_id.line_ids:
-            if line.account_id == advance_account:
+            if line.account_id == advance_account and not line.reconciled:
                 account_move_lines_to_reconcile |= line
         account_move_lines_to_reconcile.with_context(ctx).reconcile()
         return {"type": "ir.actions.act_window_close"}


### PR DESCRIPTION
Fix 2 case

- When the advance document's choose `account` does not equal the `expense account` (Product Advance), you cannot clear or return it.

>     **How to fix**
>     - Add constrains account on advance and Expense Account must be the same account

--------------------------------------------------------------

- Multi advance can't return advance.

Step to error
1. Create advance and add expense line multi (i.e. 10k and 10k)
2. Advance with normal process
3. Return Advance -> 15k (or more than 10k)
4. Return Advance again. it will error

>     **How to fix**
>     - Filter move line is not reconciled only


cc: @kittiu 