### PR TITLE
[14.0][FIX] hr_expense_advance_clearing, make expense_line_ids readonly when clear advance

### DIFF
--- a/hr_expense_advance_clearing/models/hr_expense_sheet.py
+++ b/hr_expense_advance_clearing/models/hr_expense_sheet.py
@@ -54,11 +54,10 @@ class HrExpenseSheet(models.Model):
     @api.depends("expense_line_ids")
     def _compute_advance(self):
         for sheet in self:
-            sheet.advance = (
-                sheet.expense_line_ids
-                and all(sheet.expense_line_ids.mapped("advance"))
-                or self.env.context.get("default_advance")
-            )
+            if sheet.expense_line_ids:
+                sheet.advance = all(sheet.expense_line_ids.mapped("advance"))
+            else:
+                sheet.advance = self.env.context.get("default_advance", sheet.advance)
         return
 
     @api.constrains("advance_sheet_id", "expense_line_ids")

--- a/hr_expense_advance_clearing/views/hr_expense_views.xml
+++ b/hr_expense_advance_clearing/views/hr_expense_views.xml
@@ -195,9 +195,11 @@
             </h1>
             <xpath expr="/form/sheet/group/group" position="after">
                 <group>
+                    <field name="id" invisible="1" />
                     <field
                         name="advance_sheet_id"
-                        attrs="{'invisible': [('advance', '=', True)]}"
+                        attrs="{'invisible': [('advance', '=', True)], 'readonly': [('id', '!=', False)]}"
+                        force_save="1"
                     />
                     <field
                         name="clearing_residual"
@@ -229,6 +231,10 @@
                 <attribute
                     name="context"
                 >{'default_advance': advance, 'search_default_is_advance': advance, 'search_default_is_expense': not advance, 'form_view_ref' : 'hr_expense.hr_expense_view_form_without_header', 'default_company_id': company_id, 'default_employee_id': employee_id}</attribute>
+                <attribute
+                    name="attrs"
+                >{'readonly': [('id', '=', False), ('advance_sheet_id', '!=', False)]}</attribute>
+                <attribute name="force_save">True</attribute>
             </xpath>
             <xpath expr="//notebook/page[@name='expenses']" position="after">
                 <page


### PR DESCRIPTION
For the advance with "Clearing Product" define on the advance line.
On the clearing document of that advance (i.e., click "Clear Advance"), system will default those clearing product lines in the sheet.
But, because, Odoo is using widget="many2many", when default line is set, clicking `Add a line` before saved, will result in error.

(IMHO, this is the problem of widget="many2many" to work this rare use case)

![image](https://user-images.githubusercontent.com/1973598/141141045-a31118fc-4bae-4182-9e20-63e7a74f068d.png)

FIX, in this PR, only for clear Clear Advance. When the default line is set, nor `Add a line` is allowed

![image](https://user-images.githubusercontent.com/1973598/141143798-4a26fdee-dc2d-427f-a996-2e5302442ce2.png)

After saved, `Add a line` will be usable again.

![image](https://user-images.githubusercontent.com/1973598/141143827-ee1d9366-9d2d-46d8-a0ff-1a187a2b8ba7.png)
