### PR TITLE
[14.0][FIX] hr_expense_advance_clearing: default return advance

### DIFF
--- a/hr_expense_advance_clearing/wizard/account_payment_register.py
+++ b/hr_expense_advance_clearing/wizard/account_payment_register.py
@@ -5,18 +5,20 @@ from werkzeug.urls import url_encode
 
 from odoo import _, api, models
 from odoo.exceptions import UserError
+from odoo.models import BaseModel
 
 
 class AccountPaymentRegister(models.TransientModel):
     _inherit = "account.payment.register"
 
-    def _get_default_advance(self):
-        """ This function is default_get from return advance only """
-        return {}
+    def _get_default_advance(self, fields_list):
+        """ Call default_get from BaseModel """
+        defaults = BaseModel.default_get(self, fields_list)
+        return defaults
 
     def _default_return_advance(self, fields_list):
         """ OVERRIDE: lines without check account_internal_type for return advance only """
-        res = self._get_default_advance()
+        res = self._get_default_advance(fields_list)
         if "line_ids" in fields_list:
             lines = (
                 self.env["account.move"]


### PR DESCRIPTION
[BUG]
Return Advance not default from standard
![Selection_003](https://user-images.githubusercontent.com/20896369/146866036-d3388c83-6108-47c4-8900-d89e47c5301c.png)

it's because return advance can't use default_get from `account.move`
Reference issue: https://github.com/OCA/hr-expense/issues/44
Reference PR: https://github.com/OCA/hr-expense/pull/47

[FIX]
Call `default_get` from core odoo. it will default standard field.

cc: @kittiu 
