### PR TITLE
[14.0][FIX] hr_expense_cancel: Fix tests + Cancel move payments. 

### DIFF
--- a/hr_expense_cancel/models/hr_expense.py
+++ b/hr_expense_cancel/models/hr_expense.py
@@ -107,7 +107,7 @@ class HrExpenseSheet(models.Model):
             account_move = sheet.account_move_id
             sheet.account_move_id = False
             payments = self.env["account.payment"].search(
-                [("expense_sheet_id", "=", sheet.id), ("state", "!=", "cancelled")]
+                [("expense_sheet_id", "=", sheet.id), ("state", "!=", "cancel")]
             )
             # case : cancel invoice from hr_expense
             self._remove_reconcile_hr_invoice(account_move)
@@ -153,7 +153,7 @@ class HrExpenseSheet(models.Model):
 
     def _cancel_payments(self, payments):
         for rec in payments:
-            rec.move_id.with_context({"force_delete": True}).unlink()
+            rec.move_id.button_cancel()
 
     def action_register_payment(self):
         action = super().action_register_payment()

--- a/hr_expense_cancel/tests/test_hr_expense_cancel.py
+++ b/hr_expense_cancel/tests/test_hr_expense_cancel.py
@@ -168,7 +168,10 @@ class TestHrExpenseCancel(TransactionCase):
 
         self.expense_sheet.action_cancel()
         payment = self.payment_obj.search(
-            [("expense_sheet_id", "=", self.expense_sheet.id)]
+            [
+                ("expense_sheet_id", "=", self.expense_sheet.id),
+                ("state", "!=", "cancel"),
+            ]
         )
         self.assertFalse(payment)
         self.assertFalse(self.expense_sheet.account_move_id)
@@ -187,9 +190,12 @@ class TestHrExpenseCancel(TransactionCase):
 
         self.expense_sheet.action_cancel()
         payment = self.payment_obj.search(
-            [("expense_sheet_id", "=", self.expense_sheet.id)]
+            [
+                ("expense_sheet_id", "=", self.expense_sheet.id),
+                ("state", "!=", "cancel"),
+            ]
         )
-        self.assertEqual(len(payment), 0)
+        self.assertFalse(payment)
         self.assertFalse(self.expense_sheet.account_move_id)
 
     def test_action_cancel_multi_own_account(self):
@@ -207,7 +213,10 @@ class TestHrExpenseCancel(TransactionCase):
 
         self.expense_sheet.action_cancel()
         payment = self.payment_obj.search(
-            [("expense_sheet_id", "=", self.expense_sheet.id)]
+            [
+                ("expense_sheet_id", "=", self.expense_sheet.id),
+                ("state", "!=", "cancel"),
+            ]
         )
-        self.assertEqual(len(payment), 0)
+        self.assertFalse(payment)
         self.assertFalse(self.expense_sheet.account_move_id)


### PR DESCRIPTION
Fix tests + Cancel move payments (Since odoo/odoo@64b2580).

Please @ernestotejeda and @pedrobaeza can you review it? 

@Tecnativa TT33774