### PR TITLE
[14.0][FIX] hr_expense_advance_clearing: do not allow cancel PV related clearing or return

### DIFF
--- a/hr_expense_advance_clearing/models/__init__.py
+++ b/hr_expense_advance_clearing/models/__init__.py
@@ -3,3 +3,4 @@
 from . import hr_expense
 from . import hr_expense_sheet
 from . import hr_employee_base
+from . import account_move

--- a/hr_expense_advance_clearing/models/account_move.py
+++ b/hr_expense_advance_clearing/models/account_move.py
@@ -1,0 +1,38 @@
+# Copyright 2022 Ecosoft Co., Ltd. (https://ecosoft.co.th)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from odoo import _, models
+from odoo.exceptions import UserError
+
+
+class AccountMove(models.Model):
+    _inherit = "account.move"
+
+    def _check_hr_advance_move_reconciled(self):
+        """Check if the advance move lines already cleard/returned"""
+        av_moves = self.filtered("line_ids.expense_id.sheet_id.advance")
+        emp_advance = self.env.ref("hr_expense_advance_clearing.product_emp_advance")
+        reconciled_av_move_lines = av_moves.mapped("line_ids").filtered(
+            lambda l: l.product_id == emp_advance and l.matching_number
+        )
+        if reconciled_av_move_lines:
+            raise UserError(
+                _(
+                    "This operation is not allowed as some advance amount was already "
+                    "cleared/returned.\nPlease cancel those documents first."
+                )
+            )
+
+    def button_draft(self):
+        self._check_hr_advance_move_reconciled()
+        return super().button_draft()
+
+    def button_cancel(self):
+        self._check_hr_advance_move_reconciled()
+        return super().button_cancel()
+
+    def _reverse_moves(self, default_values_list=None, cancel=False):
+        self._check_hr_advance_move_reconciled()
+        return super()._reverse_moves(
+            default_values_list=default_values_list, cancel=cancel
+        )

--- a/hr_expense_advance_clearing/models/hr_expense.py
+++ b/hr_expense_advance_clearing/models/hr_expense.py
@@ -53,7 +53,6 @@ class HrExpense(models.Model):
     @api.onchange("advance")
     def onchange_advance(self):
         self.tax_ids = False
-        self.payment_mode = "own_account"
         if self.advance:
             self.product_id = self.env.ref(
                 "hr_expense_advance_clearing.product_emp_advance"


### PR DESCRIPTION
Payment on advance shouldn't cancel if it related clearing or return advance

Step to test:
1. Create advance 100 $ and normal process until paid (it will create 1 payment)
2. Clearing or return partial advance (20 $) : Clearing Residual = 80 $
3. Go to vendor payment > select payment related from advance (1)
4. reset to draft > cancel **(it shouldn't cancel this payment)**

This PR will check and not allow cancel if clearing residual is not equal amount payment
@kittiu 