### PR TITLE
[14.0][FIX] hr_expense_advance_clearing: not allow return advance if clearing is not posted

### DIFF
--- a/hr_expense_advance_clearing/models/hr_expense.py
+++ b/hr_expense_advance_clearing/models/hr_expense.py
@@ -53,7 +53,6 @@ class HrExpense(models.Model):
     @api.onchange("advance")
     def onchange_advance(self):
         self.tax_ids = False
-        self.payment_mode = "own_account"
         if self.advance:
             self.product_id = self.env.ref(
                 "hr_expense_advance_clearing.product_emp_advance"


### PR DESCRIPTION
Do not allow `return advance` if there are clearing document state `approve`

Example:
1. AV 100
2. Clearing 20 and approve state (not posted yet)
3. Should not `Return Advance` if there are some clearing document is state `approve`
![Selection_005](https://user-images.githubusercontent.com/20896369/162554894-18035cdf-8a35-4685-88cc-38e742762d75.png)

Note: This PR solved conflict budget with `budget_control_advance_clearing`. Should we fix it in this module or `budget_control_advance_clearing`?

----------------------------------------------------
- Small FIX delete payment_mode on onchange

cc: @kittiu 
