### PR TITLE
[15.0][FIX]sale_expense_manual_reinvoice: post_install at_install test tags

### DIFF
--- a/sale_expense_manual_reinvoice/tests/test_sale_expense_manual_reinvoice.py
+++ b/sale_expense_manual_reinvoice/tests/test_sale_expense_manual_reinvoice.py
@@ -6,10 +6,12 @@ from ast import literal_eval
 
 from odoo import fields
 from odoo.exceptions import UserError
+from odoo.tests import tagged
 
 from odoo.addons.hr_expense.tests.common import TestExpenseCommon
 
 
+@tagged("post_install", "-at_install")
 class TestReInvoiceManual(TestExpenseCommon):
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
Fix to sort the error in this PR: https://github.com/OCA/hr-expense/pull/110