### PR TITLE
[14.0][FIX] hr_expense_invoice: do not display UoM and quantity label

### DIFF
--- a/hr_expense_invoice/models/hr_expense.py
+++ b/hr_expense_invoice/models/hr_expense.py
@@ -95,6 +95,7 @@ class HrExpense(models.Model):
         """
         if self.invoice_id:
             self.quantity = 1
+            self.product_uom_id = self.product_id.uom_id
             self.tax_ids = [(5,)]
             # Assign this amount after removing taxes for avoiding to raise
             # the constraint _check_expense_ids

--- a/hr_expense_invoice/views/hr_expense_views.xml
+++ b/hr_expense_invoice/views/hr_expense_views.xml
@@ -8,7 +8,18 @@
             <field name="unit_amount" position="attributes">
                 <attribute name="force_save">1</attribute>
             </field>
+            <label for="quantity" position="attributes">
+                <attribute
+                    name="attrs"
+                >{'invisible': [('invoice_id', '!=', False)]}</attribute>
+            </label>
             <field name="quantity" position="attributes">
+                <attribute name="force_save">1</attribute>
+                <attribute
+                    name="attrs"
+                >{'invisible': [('invoice_id', '!=', False)]}</attribute>
+            </field>
+            <field name="product_uom_id" position="attributes">
                 <attribute name="force_save">1</attribute>
                 <attribute
                     name="attrs"


### PR DESCRIPTION
Hide quantity label and UoM field when selecting an invoice, as it is done with quantity field.

Before:
![Peek 2022-05-25 15-48](https://user-images.githubusercontent.com/23449160/170278901-fb44df6e-f25c-4780-9f8d-a7b2c41b9aed.gif)

After:
![Peek 2022-05-25 15-48-2](https://user-images.githubusercontent.com/23449160/170279373-dcd83519-dff7-4e54-a819-004a7935803a.gif)

@ForgeFlow