### PR TITLE
[14.0][ENH] hr_expense_advance_clearing, not allow over return

### DIFF
--- a/hr_expense_advance_clearing/models/hr_expense_sheet.py
+++ b/hr_expense_advance_clearing/models/hr_expense_sheet.py
@@ -191,3 +191,13 @@ class HrExpenseSheet(models.Model):
             for k, v in clearing_dict.items()
         }
         return clearing_dict
+
+    def action_register_payment(self):
+        action = super().action_register_payment()
+        if self.env.context.get("hr_return_advance"):
+            action["context"].update(
+                {
+                    "clearing_sheet_ids": self.clearing_sheet_ids.ids,
+                }
+            )
+        return action


### PR DESCRIPTION
It is ok to make over clearing amount (use more than borrow), but is not making sense to over return amount (return unused amount more than borrow). So this PR prevent that.