### PR TITLE
[14.0] [ADD] hr_expense_upload_fix

### DIFF
--- a/hr_expense_upload_fix/__init__.py
+++ b/hr_expense_upload_fix/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/hr_expense_upload_fix/__manifest__.py
+++ b/hr_expense_upload_fix/__manifest__.py
@@ -1,0 +1,15 @@
+# Copyright 2022 ForgeFlow S.L. (https://www.forgeflow.com)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+{
+    "name": "Expense Upload Fix",
+    "summary": "Refresh products from uploaded expenses.",
+    "version": "14.0.1.0.0",
+    "license": "AGPL-3",
+    "author": "ForgeFlow, Odoo Community Association (OCA)",
+    "website": "https://github.com/OCA/hr-expense",
+    "depends": ["hr_expense"],
+    "data": [],
+    "application": False,
+    "installable": True,
+}

--- a/hr_expense_upload_fix/models/__init__.py
+++ b/hr_expense_upload_fix/models/__init__.py
@@ -1,0 +1,1 @@
+from . import hr_expense

--- a/hr_expense_upload_fix/models/hr_expense.py
+++ b/hr_expense_upload_fix/models/hr_expense.py
@@ -1,0 +1,20 @@
+# Copyright 2022 ForgeFlow S.L. (https://www.forgeflow.com)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class HrExpense(models.Model):
+    _inherit = "hr.expense"
+
+    def create_expense_from_attachments(self, attachment_ids=None, view_type="tree"):
+        res = super(HrExpense, self).create_expense_from_attachments(
+            attachment_ids, view_type
+        )
+        if res["name"] == "Generated Expense":
+            expenses = self.env["hr.expense"].browse(res["res_id"])
+        else:
+            expenses = self.env["hr.expense"].browse(res["domain"][0][2])
+        for expense in expenses:
+            expense.product_id = expense.product_id
+        return res

--- a/hr_expense_upload_fix/readme/CONTRIBUTORS.rst
+++ b/hr_expense_upload_fix/readme/CONTRIBUTORS.rst
@@ -1,0 +1,1 @@
+* Marc Belmonte <marc.belmonte@forgeflow.com>

--- a/hr_expense_upload_fix/readme/DESCRIPTION.rst
+++ b/hr_expense_upload_fix/readme/DESCRIPTION.rst
@@ -1,0 +1,1 @@
+This module fix an issue when uploading expenses that api depends don't procs on expense create.

--- a/setup/hr_expense_upload_fix/odoo/addons/hr_expense_upload_fix
+++ b/setup/hr_expense_upload_fix/odoo/addons/hr_expense_upload_fix
@@ -1,0 +1,1 @@
+../../../../hr_expense_upload_fix

--- a/setup/hr_expense_upload_fix/setup.py
+++ b/setup/hr_expense_upload_fix/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
Refresh the product after uploading an expense to trigger all api depends that do not when creating the expense. 