### PR TITLE
[14.0][IMP] hr_expense_invoice: Change _validate_expense_invoice() function to use amount_total from invoices.

### DIFF
--- a/hr_expense_invoice/models/hr_expense_sheet.py
+++ b/hr_expense_invoice/models/hr_expense_sheet.py
@@ -58,7 +58,7 @@ class HrExpenseSheet(models.Model):
         if any(invoices.filtered(lambda i: i.state != "posted")):
             raise UserError(_("Vendor bill state must be Posted"))
         expense_amount = sum(expense_lines.mapped("total_amount"))
-        invoice_amount = sum(invoices.mapped("amount_residual"))
+        invoice_amount = sum(invoices.mapped("amount_total"))
         # Expense amount must equal invoice amount
         if float_compare(expense_amount, invoice_amount, precision) != 0:
             raise UserError(


### PR DESCRIPTION
FWP from 13.0: https://github.com/OCA/hr-expense/pull/133

Change `_validate_expense_invoice()` function to use amount_total from invoices.

If residual amount from invoice is not the same, it should not show an error.

Please @pedrobaeza and @chienandalu can you review it?

@Tecnativa TT40175