### PR TITLE
[FIX][14.0] hr_expense_invoice default_move_type to show vendor

### DIFF
--- a/hr_expense_invoice/views/hr_expense_views.xml
+++ b/hr_expense_invoice/views/hr_expense_views.xml
@@ -28,8 +28,8 @@
             <field name="product_id" position="after">
                 <field
                     name="invoice_id"
-                    context="{'default_type': 'in_invoice',
-                            'type': 'in_invoice',
+                    context="{'default_move_type': 'in_invoice',
+                            'move_type': 'in_invoice',
                             'journal_type': 'purchase',
                             'default_ref': reference,
                             'default_invoice_date': date,


### PR DESCRIPTION
doesn't show vendor because type became move_type