### PR TITLE
[15.0][FIX] hr_expense_advance_clearing: zero unit price

### DIFF
--- a/hr_expense_advance_clearing/views/hr_expense_views.xml
+++ b/hr_expense_advance_clearing/views/hr_expense_views.xml
@@ -238,6 +238,12 @@
                 >{'readonly': [('id', '=', False), ('advance_sheet_id', '!=', False)]}</attribute>
                 <attribute name="force_save">True</attribute>
             </xpath>
+            <xpath
+                expr="//field[@name='expense_line_ids']/tree/field[@name='unit_amount']"
+                position="attributes"
+            >
+                <attribute name="force_save">True</attribute>
+            </xpath>
             <xpath expr="//div[@name='button_box']" position="inside">
                 <button
                     name="action_open_clearings"


### PR DESCRIPTION
Fix error when clear advance with zero unit price

![Selection_003](https://user-images.githubusercontent.com/51266019/219337968-d5fcfb6a-1607-47cb-8dd8-049cdc1e9e53.png)
