### PR TITLE
[15.0][FIX] hr_expense_advance_clearing: change field not compute advance

### DIFF
--- a/hr_expense_advance_clearing/models/hr_expense_sheet.py
+++ b/hr_expense_advance_clearing/models/hr_expense_sheet.py
@@ -11,7 +11,7 @@ class HrExpenseSheet(models.Model):
     _inherit = "hr.expense.sheet"
 
     advance = fields.Boolean(
-        string="Employee Advance", compute="_compute_advance", store=True
+        string="Employee Advance",
     )
     advance_sheet_id = fields.Many2one(
         comodel_name="hr.expense.sheet",
@@ -53,15 +53,6 @@ class HrExpenseSheet(models.Model):
         compute="_compute_amount_payable",
         help="Final regiter payment amount even after advance clearing",
     )
-
-    @api.depends("expense_line_ids")
-    def _compute_advance(self):
-        for sheet in self:
-            if sheet.expense_line_ids:
-                sheet.advance = all(sheet.expense_line_ids.mapped("advance"))
-            else:
-                sheet.advance = self.env.context.get("default_advance", sheet.advance)
-        return
 
     @api.constrains("advance_sheet_id", "expense_line_ids")
     def _check_advance_expense(self):

--- a/hr_expense_advance_clearing/tests/test_hr_expense_advance_clearing.py
+++ b/hr_expense_advance_clearing/tests/test_hr_expense_advance_clearing.py
@@ -110,6 +110,7 @@ class TestHrExpenseAdvanceClearing(common.TransactionCase):
                 "name": description,
                 "employee_id": expense.employee_id.id,
                 "expense_line_ids": [(6, 0, [expense.id])],
+                "advance": advance,
             }
         )
         return expense_sheet

--- a/hr_expense_advance_clearing/views/hr_expense_views.xml
+++ b/hr_expense_advance_clearing/views/hr_expense_views.xml
@@ -192,6 +192,8 @@
                 <field
                     name="advance"
                     attrs="{'invisible': [('advance', '=', False)]}"
+                    readonly="1"
+                    force_save="1"
                 />
                 <label for="advance" attrs="{'invisible': [('advance', '=', False)]}" />
             </h1>


### PR DESCRIPTION
[BUG]
- Duplicate advance sheet, it will change advance to expense
![2](https://user-images.githubusercontent.com/20896369/225569212-6f5ac5e8-bf76-4a34-8fb9-029cd94e79fd.gif)

- When create advance sheet and save without line, it will change advance to expense
![1](https://user-images.githubusercontent.com/20896369/225569238-0d19740d-d896-48df-9bd1-d1a10c5a7ac8.gif)

This PR solved it by change field advance in expense sheet to not compute field