### PR TITLE
[15.0][FIX] hr_expense_advance_clearing: split function return advance and check advance residual

### DIFF
--- a/hr_expense_advance_clearing/models/hr_expense.py
+++ b/hr_expense_advance_clearing/models/hr_expense.py
@@ -63,12 +63,6 @@ class HrExpense(models.Model):
         # Only when do the clearing, change cr payable to cr advance
         emp_advance = self.env.ref("hr_expense_advance_clearing.product_emp_advance")
         sheets = self.mapped("sheet_id").filtered("advance_sheet_id")
-        sheets_x = sheets.filtered(lambda x: x.advance_sheet_residual <= 0.0)
-        if sheets_x:  # Advance Sheets with no residual left
-            raise ValidationError(
-                _("Advance: %s has no amount to clear")
-                % ", ".join(sheets_x.mapped("name"))
-            )
         for sheet in sheets:
             advance_to_clear = sheet.advance_sheet_residual
             for move_lines in move_line_values_by_expense.values():

--- a/hr_expense_advance_clearing/tests/test_hr_expense_advance_clearing.py
+++ b/hr_expense_advance_clearing/tests/test_hr_expense_advance_clearing.py
@@ -212,10 +212,8 @@ class TestHrExpenseAdvanceClearing(common.TransactionCase):
         self.assertEqual(self.clearing_equal.advance_sheet_residual, 0.0)
         # Clear this with previous advance is done
         self.clearing_more.advance_sheet_id = self.advance
-        self.clearing_more.action_submit_sheet()
-        self.clearing_more.approve_expense_sheets()
         with self.assertRaises(ValidationError):
-            self.clearing_more.action_sheet_move_create()
+            self.clearing_more.action_submit_sheet()
         # There are 2 clearing in advance
         self.assertEqual(self.advance.clearing_count, 2)
         # Check link clearing in advance must be equal clearing count


### PR DESCRIPTION
This PR fix 2 commit
- Split function create payment return advance for other module can modify payment before post
- Check advance residual in state submit, approve and post. For case create 2 clearing and clearing first document until advance is no amount left. second clearing must show error