### PR TITLE
[15.0][FIX] hr_expense_petty_cash: add permission for internal user

### DIFF
--- a/hr_expense_petty_cash/models/petty_cash.py
+++ b/hr_expense_petty_cash/models/petty_cash.py
@@ -37,7 +37,7 @@ class PettyCash(models.Model):
 
     @api.depends("partner_id", "account_id")
     def _compute_petty_cash_balance(self):
-        aml_env = self.env["account.move.line"]
+        aml_env = self.sudo().env["account.move.line"]
         for rec in self:
             aml = aml_env.search(
                 [

--- a/hr_expense_petty_cash/security/ir.model.access.csv
+++ b/hr_expense_petty_cash/security/ir.model.access.csv
@@ -1,2 +1,3 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_hr_expense_petty_cash,access_hr_expense_petty_cash,model_petty_cash,account.group_account_user,1,1,1,1
+access_hr_expense_petty_cash_user,access_hr_expense_petty_cash_user,model_petty_cash,base.group_user,1,0,0,0


### PR DESCRIPTION
Add permission for internal users to be able to select petty cash holders.