### PR TITLE
[14.0][FIX] hr_expense_invoice: use bill partner in expense journal item when expense paid by company

### DIFF
--- a/hr_expense_invoice/models/hr_expense.py
+++ b/hr_expense_invoice/models/hr_expense.py
@@ -83,6 +83,18 @@ class HrExpense(models.Model):
             if not expense.invoice_id:
                 continue
             for move_line in move_lines:
+                if expense.payment_mode == "company_account":
+                    # When paying from company account means that the employee paid
+                    # with the company money.
+                    # Therefore we should expect the payment to be associated
+                    # with the vendor, not the employee.
+                    move_line[
+                        "partner_id"
+                    ] = expense.invoice_id.partner_id.commercial_partner_id.id
+                bill_ref = expense.invoice_id.name
+                if expense.invoice_id.ref:
+                    bill_ref = "%s: %s"(bill_ref, expense.invoice_id.ref)
+                move_line["name"] = "%s (%s)" % (move_line["name"], bill_ref)
                 if move_line["debit"]:
                     move_line[
                         "partner_id"

--- a/hr_expense_invoice/models/hr_expense_sheet.py
+++ b/hr_expense_invoice/models/hr_expense_sheet.py
@@ -18,12 +18,12 @@ class HrExpenseSheet(models.Model):
         res = super().action_sheet_move_create()
         for sheet in self:
             move_lines = res[sheet.id].line_ids
-            if sheet.payment_mode != "own_account":
-                continue
             for line in self.expense_line_ids.filtered("invoice_id"):
                 c_move_lines = move_lines.filtered(
                     lambda x: x.expense_id == line
                     and x.partner_id == line.invoice_id.commercial_partner_id
+                    and x.account_id.internal_type == "payable"
+                    and not x.reconciled
                 )
                 c_move_lines |= line.invoice_id.line_ids.filtered(
                     lambda x: x.account_id.internal_type == "payable"

--- a/hr_expense_invoice/tests/test_hr_expense_invoice.py
+++ b/hr_expense_invoice/tests/test_hr_expense_invoice.py
@@ -244,8 +244,8 @@ class TestHrExpenseInvoice(common.SavepointCase):
         ).action_sheet_move_create()
         self.assertEqual(self.sheet.state, "done")
         self.assertTrue(self.sheet.account_move_id)
-        # Invoice is not paid
-        self.assertEqual(self.invoice.payment_state, "not_paid")
+        # Invoice is paid
+        self.assertEqual(self.invoice.payment_state, "paid")
         # Click on View Invoice button link to the correct invoice
         res = self.sheet.action_view_invoices()
         self.assertEqual(res["view_mode"], "form")

--- a/hr_expense_invoice/views/hr_expense_views.xml
+++ b/hr_expense_invoice/views/hr_expense_views.xml
@@ -82,7 +82,7 @@
                     type="object"
                     attrs="{'invisible': [('invoice_count', '=', 0)]}"
                 >
-                    <field name="invoice_count" widget="statinfo" string="Invoices" />
+                    <field name="invoice_count" widget="statinfo" string="Bills" />
                 </button>
             </div>
         </field>


### PR DESCRIPTION
If the expense is paid by the company and the expense refers to a bill, then the company will receive charge in the company account from the vendor, not from the employee.

In addition, when the expense is paid by the company the bill should be paid (reconciled), because the expense creates an outstanding payment line, to be reconciled later in the company bank account reconciliation process.

cc @victoralmau @pedrobaeza 