### PR TITLE
[15.0][FIX] hr_expense_petty_cash: group by petty cash holder

### DIFF
--- a/hr_expense_petty_cash/models/hr_expense_sheet.py
+++ b/hr_expense_petty_cash/models/hr_expense_sheet.py
@@ -14,6 +14,7 @@ class HrExpenseSheet(models.Model):
         comodel_name="petty.cash",
         ondelete="restrict",
         compute="_compute_petty_cash",
+        store=True,
     )
 
     @api.depends("expense_line_ids", "payment_mode")


### PR DESCRIPTION
This PR is used to fix errors when grouped by Petty Cash Holder.

![Selection_136](https://github.com/OCA/hr-expense/assets/51266019/64a1e096-8818-4d88-b00d-5ae8efa89a46)
