### PR TITLE
[15.0][FIX] hr_expense_payment_widget_amount: back state to posted when unreconcile payment

### DIFF
--- a/hr_expense_payment_widget_amount/models/account_move.py
+++ b/hr_expense_payment_widget_amount/models/account_move.py
@@ -16,4 +16,7 @@ class AccountMove(models.Model):
                 [("debit_move_id", "in", self.line_ids.ids)]
             )
             partial_id = len(partial) > 1 and partial.ids or partial_id
-        return super().js_remove_outstanding_partial(partial_id)
+        res = super().js_remove_outstanding_partial(partial_id)
+        # Back state to posted (if paid)
+        self.payment_id.expense_sheet_ids.write({"state": "post"})
+        return res


### PR DESCRIPTION
Step to test
1. Create expense and process until register payment
2. Unreconcile in widget payment of expense
3. It will unreconcile payment and expense but can not register payment again