### PR TITLE
[15.0][ENH] hr_expense_petty_cash: multi-company

### DIFF
--- a/hr_expense_petty_cash/__manifest__.py
+++ b/hr_expense_petty_cash/__manifest__.py
@@ -11,6 +11,7 @@
     "depends": ["hr_expense"],
     "data": [
         "security/ir.model.access.csv",
+        "security/petty_cash_security.xml",
         "views/account_move_views.xml",
         "views/hr_expense_sheet_views.xml",
         "views/hr_expense_views.xml",

--- a/hr_expense_petty_cash/models/account_move.py
+++ b/hr_expense_petty_cash/models/account_move.py
@@ -24,7 +24,11 @@ class AccountMove(models.Model):
         petty_cash_env = self.env["petty.cash"].sudo()
         for rec in self:
             petty_cash = petty_cash_env.search(
-                [("partner_id", "=", rec.partner_id.id)], limit=1
+                [
+                    ("partner_id", "=", rec.partner_id.id),
+                    ("company_id", "=", rec.company_id.id),
+                ],
+                limit=1,
             )
             if petty_cash and rec.invoice_line_ids:
                 account = petty_cash.account_id
@@ -89,7 +93,7 @@ class AccountMove(models.Model):
         self.ensure_one()
         # Get suggested currency amount
         amount = petty_cash.petty_cash_limit - petty_cash.petty_cash_balance
-        company_currency = self.env.user.company_id.currency_id
+        company_currency = self.company_id.currency_id
         amount_doc_currency = company_currency._convert(
             amount,
             self.currency_id,
@@ -115,9 +119,13 @@ class AccountMove(models.Model):
         if self.is_petty_cash:
             if not self.partner_id:
                 raise ValidationError(_("Please select petty cash holder"))
-            # Selected parenter must be petty cash holder
+            # Selected partner must be petty cash holder
             petty_cash = self.env["petty.cash"].search(
-                [("partner_id", "=", self.partner_id.id)], limit=1
+                [
+                    ("partner_id", "=", self.partner_id.id),
+                    ("company_id", "=", self.company_id.id),
+                ],
+                limit=1,
             )
             if not petty_cash:
                 raise ValidationError(

--- a/hr_expense_petty_cash/models/hr_expense.py
+++ b/hr_expense_petty_cash/models/hr_expense.py
@@ -14,6 +14,7 @@ class HrExpense(models.Model):
         string="Petty cash holder",
         comodel_name="petty.cash",
         ondelete="restrict",
+        check_company=True,
         readonly=True,
         states={"draft": [("readonly", False)]},
     )

--- a/hr_expense_petty_cash/models/petty_cash.py
+++ b/hr_expense_petty_cash/models/petty_cash.py
@@ -8,17 +8,20 @@ class PettyCash(models.Model):
     _name = "petty.cash"
     _description = "Petty Cash"
     _rec_name = "partner_id"
+    _check_company_auto = True
 
     active = fields.Boolean(default=True)
     partner_id = fields.Many2one(
         comodel_name="res.partner",
         string="Petty Cash Holder",
         required=True,
+        check_company=True,
     )
     account_id = fields.Many2one(
         comodel_name="account.account",
         string="Petty Cash Account",
         required=True,
+        check_company=True,
     )
     petty_cash_limit = fields.Float(
         string="Max Limit",
@@ -30,9 +33,20 @@ class PettyCash(models.Model):
     )
     journal_id = fields.Many2one(
         comodel_name="account.journal",
+        check_company=True,
     )
+    company_id = fields.Many2one(
+        comodel_name="res.company",
+        required=True,
+        default=lambda self: self.env.company,
+    )
+
     _sql_constraints = [
-        ("partner_uniq", "unique(partner_id)", "Petty Cash Holder must be unique!"),
+        (
+            "partner_uniq",
+            "unique(partner_id, company_id)",
+            "Petty Cash Holder must be unique!",
+        ),
     ]
 
     @api.depends("partner_id", "account_id")

--- a/hr_expense_petty_cash/security/petty_cash_security.xml
+++ b/hr_expense_petty_cash/security/petty_cash_security.xml
@@ -1,0 +1,10 @@
+<odoo noupdate="1">
+    <record id="petty_cash_rule" model="ir.rule">
+        <field name="name">Petty Cash multi-company</field>
+        <field name="model_id" ref="model_petty_cash" />
+        <field name="global" eval="True" />
+        <field name="domain_force">
+            ['|',('company_id','=',False),('company_id','in',company_ids)]
+        </field>
+    </record>
+</odoo>

--- a/hr_expense_petty_cash/static/description/index.html
+++ b/hr_expense_petty_cash/static/description/index.html
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>

--- a/hr_expense_petty_cash/views/petty_cash_views.xml
+++ b/hr_expense_petty_cash/views/petty_cash_views.xml
@@ -23,6 +23,10 @@
                             <field name="journal_id" />
                         </group>
                         <group name="petty_cash">
+                            <field
+                                name="company_id"
+                                groups="base.group_multi_company"
+                            />
                             <field name="petty_cash_limit" />
                             <field name="petty_cash_balance" />
                         </group>
@@ -41,6 +45,7 @@
                 <field name="journal_id" />
                 <field name="petty_cash_limit" sum="Limit" />
                 <field name="petty_cash_balance" sum="Balance" />
+                <field name="company_id" groups="base.group_multi_company" />
             </tree>
         </field>
     </record>
@@ -87,6 +92,12 @@
                     domain="[('journal_id','!=',False)]"
                 />
                 <group expand="0" string="Group By">
+                    <filter
+                        name="group_by_company"
+                        string="Company"
+                        context="{'group_by': 'company_id'}"
+                        groups="base.group_multi_company"
+                    />
                     <filter
                         name="partner"
                         string="Petty Cash Holder"


### PR DESCRIPTION
Support Multi-Company

What's new?
- Add field and rule on petty cash menu
![Selection_011](https://github.com/OCA/hr-expense/assets/20896369/88a40a7a-fa9f-4bd7-b0c1-ce189d3014ba)
- change domain account and journal in petty cash must be depend on company
- change constraints uniq with partner and company