### PR TITLE
[16.0][FIX] hr_expense_invoice: taxes propagation

### DIFF
--- a/hr_expense_invoice/models/hr_expense.py
+++ b/hr_expense_invoice/models/hr_expense.py
@@ -185,7 +185,7 @@ class HrExpense(models.Model):
     def _compute_tax_ids(self):
         with_invoice = self.filtered("invoice_id")
         # for record in with_invoice:
-            # record.tax_ids = [(5,)]
+        # record.tax_ids = [(5,)]
         return super(HrExpense, self - with_invoice)._compute_tax_ids()
 
     @api.depends(

--- a/hr_expense_invoice/models/hr_expense.py
+++ b/hr_expense_invoice/models/hr_expense.py
@@ -36,7 +36,7 @@ class HrExpense(models.Model):
                 {
                     "product_id": self.product_id.id,
                     "name": self.name,
-                    "price_unit": self.unit_amount or self.total_amount,
+                    "price_unit": self.untaxed_amount or self.total_amount,
                     "quantity": self.quantity,
                     "account_id": self.account_id.id,
                     "analytic_distribution": self.analytic_distribution,
@@ -130,7 +130,6 @@ class HrExpense(models.Model):
             {
                 "invoice_id": invoice.id,
                 "quantity": 1,
-                "tax_ids": False,
                 "unit_amount": invoice.amount_total,
             }
         )
@@ -185,8 +184,8 @@ class HrExpense(models.Model):
     @api.depends("invoice_id")
     def _compute_tax_ids(self):
         with_invoice = self.filtered("invoice_id")
-        for record in with_invoice:
-            record.tax_ids = [(5,)]
+        # for record in with_invoice:
+            # record.tax_ids = [(5,)]
         return super(HrExpense, self - with_invoice)._compute_tax_ids()
 
     @api.depends(

--- a/hr_expense_invoice/tests/test_hr_expense_invoice.py
+++ b/hr_expense_invoice/tests/test_hr_expense_invoice.py
@@ -269,8 +269,11 @@ class TestHrExpenseInvoice(TestExpenseCommon):
         # use the actual action instead. This is a workaround.
         res = self.expense.action_submit_expenses()
         # The base create cleans the context, so we have to pass the values.
-        sheet_values = {field.replace("default_", ""): res["context"][field] for field in res["context"]}
-        sheet = self.env[["hr.expense.sheet"]].create(sheet_values)
+        sheet_values = {
+            field.replace("default_", ""): res["context"][field]
+            for field in res["context"]
+        }
+        sheet = self.env["hr.expense.sheet"].create(sheet_values)
         self.assertEqual(sheet.expense_line_ids.tax_ids, tax_id)
         self.assertEqual(self.expense.tax_ids, tax_id)
         self.assertAlmostEqual(sheet.untaxed_amount, 20.0, places=2)


### PR DESCRIPTION
There is an error in the expense sheet when we have set the taxes. Also if we try to create the expense sheet without taxes and then correct it in the invoice we will get the error that the total of the invoice does not match the total of the expense.

At the moment we create an invoice from the expense sheet the information of the tax fields is deleted, leaving the records incoherent.


@moduon MT-5202