### PR TITLE
[15.0] Replace 'Camptocamp SA' with 'Camptocamp'

### DIFF
--- a/sale_expense_cost_reinvoice/README.rst
+++ b/sale_expense_cost_reinvoice/README.rst
@@ -51,7 +51,7 @@ Credits
 Authors
 ~~~~~~~
 
-* Camptocamp SA
+* Camptocamp
 
 Contributors
 ~~~~~~~~~~~~

--- a/sale_expense_cost_reinvoice/__manifest__.py
+++ b/sale_expense_cost_reinvoice/__manifest__.py
@@ -4,8 +4,8 @@
 {
     "name": "Sale Expense Auto Re-invoice at cost",
     "summary": "Provide cost on order line when Auto Re-invoice at cost",
-    "version": "15.0.1.0.0",
-    "author": "Camptocamp SA, Odoo Community Association (OCA)",
+    "version": "15.0.1.0.1",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/hr-expense",
     "license": "AGPL-3",
     "category": "Human Resources",

--- a/sale_expense_cost_reinvoice/static/description/index.html
+++ b/sale_expense_cost_reinvoice/static/description/index.html
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
@@ -9,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -275,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -301,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -396,7 +396,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <div class="section" id="authors">
 <h2><a class="toc-backref" href="#toc-entry-3">Authors</a></h2>
 <ul class="simple">
-<li>Camptocamp SA</li>
+<li>Camptocamp</li>
 </ul>
 </div>
 <div class="section" id="contributors">
@@ -414,7 +414,9 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-5">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>

--- a/sale_expense_manual_reinvoice/README.rst
+++ b/sale_expense_manual_reinvoice/README.rst
@@ -84,7 +84,7 @@ Credits
 Authors
 ~~~~~~~
 
-* Camptocamp SA
+* Camptocamp
 
 Contributors
 ~~~~~~~~~~~~

--- a/sale_expense_manual_reinvoice/__manifest__.py
+++ b/sale_expense_manual_reinvoice/__manifest__.py
@@ -5,8 +5,8 @@
 {
     "name": "Sale Expense Manual Re-invoice",
     "summary": "Allow to manually re-invoice expenses",
-    "version": "15.0.1.0.1",
-    "author": "Camptocamp SA, Odoo Community Association (OCA)",
+    "version": "15.0.1.0.2",
+    "author": "Camptocamp, Odoo Community Association (OCA)",
     "maintainers": ["ivantodorovich"],
     "website": "https://github.com/OCA/hr-expense",
     "license": "AGPL-3",

--- a/sale_expense_manual_reinvoice/static/description/index.html
+++ b/sale_expense_manual_reinvoice/static/description/index.html
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
@@ -9,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -275,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -301,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -425,7 +425,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <div class="section" id="authors">
 <h2><a class="toc-backref" href="#toc-entry-6">Authors</a></h2>
 <ul class="simple">
-<li>Camptocamp SA</li>
+<li>Camptocamp</li>
 </ul>
 </div>
 <div class="section" id="contributors">
@@ -443,7 +443,9 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-8">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>


### PR DESCRIPTION
This pull request contains changes to replace 'Camptocamp SA' with 'Camptocamp' in __manifest__.py files for branch 15.0.