### PR TITLE
[16.0][FIX] hr_expense_advance_clearing: clear advance partial

### DIFF
--- a/hr_expense_advance_clearing/models/account_move.py
+++ b/hr_expense_advance_clearing/models/account_move.py
@@ -1,7 +1,7 @@
 # Copyright 2022 Ecosoft Co., Ltd. (https://ecosoft.co.th)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
-from odoo import _, models
+from odoo import _, api, models
 from odoo.exceptions import UserError
 
 
@@ -36,3 +36,44 @@ class AccountMove(models.Model):
         return super()._reverse_moves(
             default_values_list=default_values_list, cancel=cancel
         )
+
+    @api.depends(
+        "line_ids.matched_debit_ids.debit_move_id.move_id.payment_id.is_matched",
+        "line_ids.matched_debit_ids.debit_move_id.move_id.line_ids.amount_residual",
+        "line_ids.matched_debit_ids.debit_move_id.move_id.line_ids.amount_residual_currency",
+        "line_ids.matched_credit_ids.credit_move_id.move_id.payment_id.is_matched",
+        "line_ids.matched_credit_ids.credit_move_id.move_id.line_ids.amount_residual",
+        "line_ids.matched_credit_ids.credit_move_id.move_id.line_ids.amount_residual_currency",
+        "line_ids.balance",
+        "line_ids.currency_id",
+        "line_ids.amount_currency",
+        "line_ids.amount_residual",
+        "line_ids.amount_residual_currency",
+        "line_ids.payment_id.state",
+        "line_ids.full_reconcile_id",
+        "state",
+    )
+    def _compute_amount(self):
+        """Compute amount residual for advance clearing case."""
+        res = super()._compute_amount()
+        for move in self:
+            total_residual = 0.0
+            total_residual_currency = 0.0
+            for line in move.line_ids:
+                if line.account_type not in ("asset_receivable", "liability_payable"):
+                    continue
+                # Line residual amount.
+                clearing = line.expense_id.sheet_id.filtered(
+                    lambda sheet: sheet.advance_sheet_id
+                )
+                if clearing:
+                    # Residual amount.
+                    total_residual += line.amount_residual
+                    total_residual_currency += line.amount_residual_currency
+
+            # Update amount residual for case clearing
+            if total_residual and total_residual_currency:
+                sign = move.direction_sign
+                move.amount_residual = -sign * total_residual
+                move.amount_residual_signed = total_residual_currency
+        return res

--- a/hr_expense_advance_clearing/models/hr_expense_sheet.py
+++ b/hr_expense_advance_clearing/models/hr_expense_sheet.py
@@ -66,10 +66,16 @@ class HrExpenseSheet(models.Model):
 
     @api.depends("account_move_id.payment_state")
     def _compute_payment_state(self):
-        """After clear advance. payment state will change to 'paid'"""
+        """After clear advance.
+        if amount residual is zero, payment state will change to 'paid'
+        """
         res = super()._compute_payment_state()
         for sheet in self:
-            if sheet.advance_sheet_id and sheet.account_move_id.state == "posted":
+            if (
+                sheet.advance_sheet_id
+                and sheet.account_move_id.state == "posted"
+                and not sheet.amount_residual
+            ):
                 sheet.payment_state = "paid"
         return res
 


### PR DESCRIPTION
Step to test:
1. Create advance 100
2. Clear advance 150
![Selection_005](https://github.com/OCA/hr-expense/assets/20896369/dc1a8b16-3393-459d-bba9-9c5484684850)
3. When register payment clearing with partial it will change state to done
![Selection_006](https://github.com/OCA/hr-expense/assets/20896369/0c08a5ca-e284-431f-8155-c3e9ead84ba4)
![Selection_007](https://github.com/OCA/hr-expense/assets/20896369/e6908d51-9e42-4b9a-a792-dae15e53bbc1)

This PR fixed allow partial payment clearing