### PR TITLE
IMP hr_exp_sheet: switch to @api.model_create_multi

### DIFF
--- a/hr_expense_sequence/models/hr_expense_sheet.py
+++ b/hr_expense_sequence/models/hr_expense_sheet.py
@@ -11,9 +11,11 @@ class HrExpenseSheet(models.Model):
 
     number = fields.Char(required=True, default="/", readonly=True, copy=False)
 
-    @api.model
-    def create(self, vals):
-        if vals.get("number", "/") == "/":
-            number = self.env["ir.sequence"].next_by_code("hr.expense.sheet") or "/"
-            vals["number"] = number
-        return super().create(vals)
+    @api.model_create_multi
+    def create(self, vals_list):
+        for vals in vals_list:
+            if vals.get("number", "/") == "/":
+                vals["number"] = (
+                    self.env["ir.sequence"].next_by_code("hr.expense.sheet") or "/"
+                )
+        return super().create(vals_list)


### PR DESCRIPTION
Avoid `WARNING db odoo.api.create: The model odoo.addons.hr_expense_sequence.models.hr_expense_sheet is not overriding the create method in batch`

