### PR TITLE
[16.0][FIX] hr_expense_advance_clearing: visible analytic

### DIFF
--- a/hr_expense_advance_clearing/views/hr_expense_views.xml
+++ b/hr_expense_advance_clearing/views/hr_expense_views.xml
@@ -141,11 +141,6 @@
                     placeholder="Optional clearing product is used during clear advance"
                 />
             </field>
-            <field name="analytic_distribution" position="attributes">
-                <attribute name="attrs">
-                    {'invisible': [('advance', '!=', False)]}
-                </attribute>
-            </field>
         </field>
     </record>
     <record id="view_hr_expense_sheet_tree" model="ir.ui.view">


### PR DESCRIPTION
This PR delete code invisible analytic.
I can't remember why we invisible analytic in advance?

What do you think? @kittiu 