### PR TITLE
[Fix 17.0] hr_expense_invoice

### DIFF
--- a/hr_expense_invoice/models/hr_expense_sheet.py
+++ b/hr_expense_invoice/models/hr_expense_sheet.py
@@ -37,7 +37,7 @@ class HrExpenseSheet(models.Model):
                 )
                 transfer_line = move.line_ids.filtered(
                     lambda x: x.partner_id
-                    == self.expense_line_ids.invoice_id.partner_id
+                    == expense.invoice_id.partner_id
                 )
                 (ap_lines + transfer_line).reconcile()
         return res

--- a/hr_expense_invoice/models/hr_expense_sheet.py
+++ b/hr_expense_invoice/models/hr_expense_sheet.py
@@ -36,8 +36,8 @@ class HrExpenseSheet(models.Model):
                     lambda x: x.display_type == "payment_term"
                 )
                 transfer_line = move.line_ids.filtered(
-                    lambda x: x.partner_id
-                    == expense.invoice_id.partner_id
+                    lambda x, partner=expense.invoice_id.partner_id: 
+                        x.partner_id == partner
                 )
                 (ap_lines + transfer_line).reconcile()
         return res


### PR DESCRIPTION

Fixes issue:
https://github.com/OCA/hr-expense/issues/273

If an expense report includes invoices from diferent providers, when posting move the report moves to "paid" and invoices are not reconciled as paid, as it fails to reconcile the lines with the transfer moves.

Use the correct partner, from current expense line from the report, not always the same partner from first expense line
