### PR TITLE
[Fix 16.0] hr_expense_invoice

### DIFF
--- a/hr_expense_invoice/models/hr_expense.py
+++ b/hr_expense_invoice/models/hr_expense.py
@@ -72,7 +72,7 @@ class HrExpense(models.Model):
                     lambda x: x.display_type == "payment_term"
                 )
                 transfer_line = move.line_ids.filtered(
-                    lambda x: x.partner_id == self.invoice_id.partner_id
+                    lambda x: x.partner_id == expense.invoice_id.partner_id
                 )
                 (ap_lines + transfer_line).reconcile()
         return res


### PR DESCRIPTION
Fixes issue:
https://github.com/OCA/hr-expense/issues/273

If an expense report includes invoices from diferent providers, when posting move the report moves to "paid" and invoices are not reconciled as paid, as it fails to reconcile the lines with the transfer moves.

Use the correct partner, from current expense line from the report, not always the same partner from first expense line