### PR TITLE
[17.0][FIX] hr_expense_invoice: Proper partner

### DIFF
--- a/hr_expense_invoice/models/hr_expense_sheet.py
+++ b/hr_expense_invoice/models/hr_expense_sheet.py
@@ -36,8 +36,8 @@ class HrExpenseSheet(models.Model):
                     lambda x: x.display_type == "payment_term"
                 )
                 transfer_line = move.line_ids.filtered(
-                    lambda x: x.partner_id
-                    == self.expense_line_ids.invoice_id.partner_id
+                    lambda x, partner=expense.invoice_id.partner_id: x.partner_id
+                    == partner
                 )
                 (ap_lines + transfer_line).reconcile()
         return res


### PR DESCRIPTION
If an expense report includes invoices from different providers, when posting move the report moves to "paid" and invoices are not reconciled as paid, as it fails to reconcile the lines with the transfer moves.

Use the correct partner, from current expense line from the report, not always the same partner from first expense line.

Fixes https://github.com/OCA/hr-expense/issues/273