### PR TITLE
[15.0][FIX] hr_expense_pay_to_vendor: support cashbasis

### DIFF
--- a/hr_expense_pay_to_vendor/models/hr_expense.py
+++ b/hr_expense_pay_to_vendor/models/hr_expense.py
@@ -22,6 +22,7 @@ class HrExpense(models.Model):
             payment_mode = sheet.payment_mode
             vendor_id = sheet.vendor_id.id
             if payment_mode == "company_account" and vendor_id:
+                tax_repartition_line = self.env["account.tax.repartition.line"]
                 for expense_id, vals in move_line_values_by_expense.items():
                     expense = self.env["hr.expense"].browse(expense_id)
                     move_line_name = (
@@ -31,6 +32,14 @@ class HrExpense(models.Model):
                     account_dst = expense._get_expense_account_destination()
                     account_ids = [account_src.id, account_dst]
                     for val in vals:
+                        # For case cash basis
+                        if val.get("tax_repartition_line_id"):
+                            cash_basis = tax_repartition_line.browse(
+                                val["tax_repartition_line_id"]
+                            ).invoice_tax_id.cash_basis_transition_account_id
+                            if cash_basis:
+                                val["account_id"] = cash_basis.id
+                        # Update partner each line
                         val["partner_id"] = vendor_id
                         if val["account_id"] in account_ids:
                             val["name"] = move_line_name


### PR DESCRIPTION
Step to test (with install hr_expense_exclude_tax):
1. Config open cash basis and create CoA
![Selection_006](https://github.com/user-attachments/assets/4625330a-2910-4217-a363-a2344c0f7b49)

2. Add new taxes with tax type purchase and account with Waiting (Cash basis Transition Account = 000001 Undue)
![Selection_007](https://github.com/user-attachments/assets/7009a7c1-4d3d-47a1-9e9b-cfd865814b54)

3. Create expense with pay to vendor and add taxes cash basis.
4. Post Journal Entry. it will create journal items tax with account Waiting
![Selection_008](https://github.com/user-attachments/assets/b4ad43c5-94ab-4401-956a-a70c302a8301)

It should account Undue
![Selection_009](https://github.com/user-attachments/assets/e8cff8f6-126f-47a7-b4e6-dde85d69b4d8)
