### PR TITLE
[16.0][FIX] hr_expense_invoice: Delete the lines that are already invoiced when creating the bill values

### DIFF
--- a/hr_expense_invoice/__manifest__.py
+++ b/hr_expense_invoice/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     "name": "Supplier invoices on HR expenses",
-    "version": "16.0.2.0.3",
+    "version": "16.0.2.0.4",
     "category": "Human Resources",
     "author": "Tecnativa, Odoo Community Association (OCA)",
     "license": "AGPL-3",

--- a/hr_expense_invoice/models/hr_expense_sheet.py
+++ b/hr_expense_invoice/models/hr_expense_sheet.py
@@ -2,7 +2,7 @@
 # Copyright 2015-2024 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
-from odoo import _, api, fields, models
+from odoo import _, api, fields, models, Command
 from odoo.exceptions import UserError
 from odoo.tools import float_compare
 
@@ -112,3 +112,9 @@ class HrExpenseSheet(models.Model):
             action["view_mode"] = "tree,form"
             action["domain"] = [("id", "in", invoice_ids)]
         return action
+
+    def _prepare_bill_vals(self):
+        ret = super(HrExpenseSheet, self)._prepare_bill_vals()
+        ret['line_ids'] = [Command.create(expense._prepare_move_line_vals()) for expense in self.expense_line_ids.filtered(lambda r: not r.invoice_id)]
+        return ret
+

--- a/hr_expense_invoice/models/hr_expense_sheet.py
+++ b/hr_expense_invoice/models/hr_expense_sheet.py
@@ -2,7 +2,7 @@
 # Copyright 2015-2024 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
-from odoo import _, api, fields, models, Command
+from odoo import Command, _, api, fields, models
 from odoo.exceptions import UserError
 from odoo.tools import float_compare
 
@@ -115,6 +115,9 @@ class HrExpenseSheet(models.Model):
 
     def _prepare_bill_vals(self):
         ret = super(HrExpenseSheet, self)._prepare_bill_vals()
-        ret['line_ids'] = [Command.create(expense._prepare_move_line_vals()) for expense in self.expense_line_ids.filtered(lambda r: not r.invoice_id)]
+        ret["line_ids"] = [
+            Command.create(expense._prepare_move_line_vals())
+            for expense in self.expense_line_ids.filtered(lambda r: not r.invoice_id)
+        ]
         return ret
 

--- a/hr_expense_invoice/models/hr_expense_sheet.py
+++ b/hr_expense_invoice/models/hr_expense_sheet.py
@@ -120,4 +120,3 @@ class HrExpenseSheet(models.Model):
             for expense in self.expense_line_ids.filtered(lambda r: not r.invoice_id)
         ]
         return ret
-


### PR DESCRIPTION
Fixes #302

This PR solves the issue where expenses are duplicated when they are already linked to an invoice.