### PR TITLE
[18.0][FIX]  hr_expense_advance_clearing: Check approval before other modules might intervene.

### DIFF
--- a/hr_expense_advance_clearing/models/hr_expense_sheet.py
+++ b/hr_expense_advance_clearing/models/hr_expense_sheet.py
@@ -243,7 +243,9 @@ class HrExpenseSheet(models.Model):
             # Advance Sheets with no residual left
             if self.advance_sheet_residual <= 0.0:
                 raise ValidationError(
-                    self.env._(f"Advance: {self.name} has no amount to clear")
+                    self.env._(
+                        "Advance: %(name)s has no amount to clear", name=self.name
+                    )
                 )
             res.update(
                 {
@@ -254,6 +256,18 @@ class HrExpenseSheet(models.Model):
                 }
             )
         return res
+
+    def _check_can_approve(self):
+        """Check advance residual before approval"""
+        for sheet in self.filtered("advance_sheet_id"):
+            if sheet.advance_sheet_residual <= 0.0:
+                raise ValidationError(
+                    self.env._(
+                        "Advance: %(name)s has no amount to clear",
+                        name=sheet.advance_sheet_id.name,
+                    )
+                )
+        return super()._check_can_approve()
 
     def open_clear_advance(self):
         self.ensure_one()


### PR DESCRIPTION
While migrating hr_expense_invoice https://github.com/OCA/hr-expense/pull/308, it conflicted with this module, so i made a fix.

This is the error in ci: https://github.com/OCA/hr-expense/actions/runs/16047191168/job/45281217754#step:8:176

I don't have enough experience with this module to know if it will have undesired side effects, however in my tests, i haven't found any.

I also fixed translations for validation errors, as f strings are not properly translatable.

Can you please review?

@kittiu @Saran440 

@Tecnativa TT55529