### PR TITLE
[16.0][IMP] hr_expense_tier_validation: Change the use of the validated field to validation_status

### DIFF
--- a/hr_expense_tier_validation/models/hr_expense.py
+++ b/hr_expense_tier_validation/models/hr_expense.py
@@ -26,8 +26,8 @@ class HrExpense(models.Model):
             if (
                 rec.sheet_id.state == "submit"
                 and rec.sheet_id.review_ids
-                and not rec.sheet_id.validated
-                and not rec.sheet_id.rejected
+                and not rec.sheet_id.validation_status == "validated"
+                and not rec.sheet_id.validation_status == "rejected"
                 and not rec._check_allow_write_under_validation(vals)
             ):
                 raise ValidationError(_("The expense report is under validation."))

--- a/hr_expense_tier_validation/tests/test_hr_expense_tier_validation.py
+++ b/hr_expense_tier_validation/tests/test_hr_expense_tier_validation.py
@@ -63,7 +63,6 @@ class TestHrExpenseTierValidation(TestExpenseCommon):
             sheet.approve_expense_sheets()
         sheet.request_validation()
         self.assertTrue(sheet)
-        sheet.invalidate_model()
         # tier validation but state still submit
         self.assertEqual(sheet.state, "submit")
         # not allow edit expense when under validation

--- a/hr_expense_tier_validation/views/hr_expense_sheet_view.xml
+++ b/hr_expense_tier_validation/views/hr_expense_sheet_view.xml
@@ -18,7 +18,7 @@
                 <filter
                     name="tier_validated"
                     string="Validated"
-                    domain="[('validated', '=', True)]"
+                    domain="[('validation_status', '=', 'validated')]"
                     help="Expense report validated and ready to be approved"
                 />
             </filter>


### PR DESCRIPTION
Change the use of the `validated` field to `validation_status`

Related to https://github.com/OCA/server-ux/pull/1084

Please @pedrobaeza can you review it?

@Tecnativa