### PR TITLE
[18.0][FIX] hr_expense_invoice: Use base amount

### DIFF
--- a/hr_expense_invoice/models/hr_expense.py
+++ b/hr_expense_invoice/models/hr_expense.py
@@ -40,8 +40,10 @@ class HrExpense(models.Model):
                 {
                     "product_id": self.product_id.id,
                     "name": self.name,
-                    "price_unit": self.price_unit or self.total_amount_currency,
-                    "quantity": self.quantity,
+                    # Odoo considers always the amount taxes included, we need to take
+                    # the base amount and quantity = 1
+                    "price_unit": self.untaxed_amount_currency,
+                    "quantity": 1,
                     "account_id": self.account_id.id,
                     "analytic_distribution": self.analytic_distribution,
                     "tax_ids": [Command.set(self.tax_ids.ids)],


### PR DESCRIPTION
Forward-port of #304 

Odoo is handling the amount always tax included, so we need to transfer to the invoice the proper base amount, not the price unit.

@Tecnativa