### PR TITLE
[18.0][FIX] hr_expense_invoice: Handle mixed lines

### DIFF
--- a/hr_expense_invoice/models/hr_expense_sheet.py
+++ b/hr_expense_invoice/models/hr_expense_sheet.py
@@ -17,18 +17,9 @@ class HrExpenseSheet(models.Model):
             lambda sheet: func(expense.invoice_id for expense in sheet.expense_line_ids)
         )
 
-    def _do_create_moves(self):
-        """Don't let super to create any move:
-        - Paid by company: there's already the invoice.
-        - Paid by employee: we create here a journal entry transferring the AP
-          balance from the invoice partner to the employee.
-        """
-        expense_sheets_with_invoices = self.get_expense_sheets_with_invoices(all)
-        res = super(
-            HrExpenseSheet, self - expense_sheets_with_invoices
-        )._do_create_moves()
+    def _do_create_ap_moves(self):
         # Create AP transfer entry for expenses paid by employees
-        for expense in expense_sheets_with_invoices.expense_line_ids:
+        for expense in self.expense_line_ids.filtered("invoice_id"):
             if expense.payment_mode == "own_account":
                 move_vals = expense._prepare_own_account_transfer_move_vals()
                 move = self.env["account.move"].create(move_vals)
@@ -42,21 +33,17 @@ class HrExpenseSheet(models.Model):
                     == partner
                 )
                 (ap_lines + transfer_line).reconcile()
-        return res
 
     def action_sheet_move_post(self):
-        """Perform extra checks and set proper payment state according linked
-        invoices.
-        """
-        expense_sheets_with_invoices = self.get_expense_sheets_with_invoices(all)
-        res = super(
-            HrExpenseSheet, self - expense_sheets_with_invoices
-        ).action_sheet_move_post()
-
-        for expense in expense_sheets_with_invoices:
+        # Handle expense sheets with invoices
+        sheets_all_inovices = self.get_expense_sheets_with_invoices(all)
+        res = super(HrExpenseSheet, self - sheets_all_inovices).action_sheet_move_post()
+        # Use 'any' here because there may be mixed sheets
+        # and we have to create ap moves for those invoices
+        for expense in self.get_expense_sheets_with_invoices(any):
             expense._validate_expense_invoice()
             expense._check_can_create_move()
-            expense._do_create_moves()
+            expense._do_create_ap_moves()
             # The payment state is set in a fixed way in super, but it depends on the
             # payment state of the invoices when there are some of them linked
             expense.filtered(
@@ -121,10 +108,11 @@ class HrExpenseSheet(models.Model):
             expenses_without_invoice = self.expense_line_ids.filtered(
                 lambda r: not r.invoice_id
             )
-            res["line_ids"] = [
-                Command.create(expense._prepare_move_lines_vals())
-                for expense in expenses_without_invoice
-            ]
+            if expenses_without_invoice:
+                res["line_ids"] = [
+                    Command.create(expense._prepare_move_lines_vals())
+                    for expense in expenses_without_invoice
+                ]
 
         return res
 
@@ -227,8 +215,8 @@ class HrExpenseSheet(models.Model):
         res = super(
             HrExpenseSheet, self - expense_sheets_with_invoices
         )._check_can_create_move()
-        # We copy this method because the expenses are in 'approve'
-        # state instead of 'submit'
+        # We copy this method because the expenses are in 'approve' or 'posted'
+        # in case this is the second run, instead of 'submit'
         if any(not sheet.expense_line_ids for sheet in expense_sheets_with_invoices):
             raise UserError(
                 self.env._(
@@ -236,7 +224,10 @@ class HrExpenseSheet(models.Model):
                         report without expenses."
                 )
             )
-        if any(sheet.state != "approve" for sheet in expense_sheets_with_invoices):
+        if any(
+            sheet.state not in ["approve", "post"]
+            for sheet in expense_sheets_with_invoices
+        ):
             raise UserError(
                 self.env._(
                     "You can only generate an accounting entry for approved expense(s)."

--- a/hr_expense_invoice/tests/test_hr_expense_invoice.py
+++ b/hr_expense_invoice/tests/test_hr_expense_invoice.py
@@ -253,8 +253,39 @@ class TestHrExpenseInvoice(TestExpenseCommon):
             f.invoice_id = self.invoice
         sheet.action_approve_expense_sheets()
         sheet.action_sheet_move_post()
-        self.assertEqual(len(sheet.account_move_ids.invoice_line_ids), 1)
+        self.assertEqual(len(sheet.account_move_ids[0].invoice_line_ids), 1)
         self.assertEqual(
-            sheet.account_move_ids.invoice_line_ids.price_total,
+            sheet.account_move_ids[0].invoice_line_ids.price_total,
             self.expense2.total_amount,
         )
+        self.assertEqual(
+            sheet.account_move_ids[1].amount_total,
+            self.expense.total_amount,
+        )
+
+    def test_6_hr_expense_mixed_invoice_same_sheet(self):
+        # We add 3 expenses
+        self.expense.price_unit = 10
+        self.expense2.price_unit = 20
+        self.expense3.price_unit = 30
+        expenses = self.expense + self.expense2 + self.expense3
+        sheet = self._action_submit_expenses(expenses)
+        self.assertIn(self.expense, sheet.expense_line_ids)
+        self.assertIn(self.expense2, sheet.expense_line_ids)
+        self.assertIn(self.expense3, sheet.expense_line_ids)
+        # We add invoices to expenses 1 and 2
+        self.invoice.action_post()
+        self.invoice2.action_post()
+        self.expense.invoice_id = self.invoice.id
+        self.expense2.invoice_id = self.invoice2.id
+        # We approve sheet
+        sheet.action_approve_expense_sheets()
+        self.assertEqual(sheet.state, "approve")
+        self.assertFalse(sheet.account_move_ids)
+        # We post journal entries
+        sheet.action_sheet_move_post()
+        self.assertEqual(sheet.state, "post")
+        self.assertEqual(self.invoice.payment_state, "paid")
+        self.assertEqual(self.invoice2.payment_state, "paid")
+        # 2 ap moves and 1 vendor bill
+        self.assertEqual(len(sheet.account_move_ids), 3)


### PR DESCRIPTION
Before this PR, if an expense report contained a mix of lines with invoices and lines without invoices, the AP transfer was not created.
A small adjustment was made to `test_5`, and a new test was added to explicitly cover this scenario (even though `test_5` now also validates it).

@Tecnativa TT59171