### PR TITLE
[18.0] [REF] hr_expense_advance_clearing: Check if all moves are posted (compatibility)

### DIFF
--- a/hr_expense_advance_clearing/models/hr_expense_sheet.py
+++ b/hr_expense_advance_clearing/models/hr_expense_sheet.py
@@ -78,7 +78,7 @@ class HrExpenseSheet(models.Model):
         for sheet in self:
             if (
                 sheet.advance_sheet_id
-                and sheet.account_move_ids.state == "posted"
+                and set(sheet.account_move_ids.mapped("state")) == {"posted"}
                 and not sheet.amount_residual
             ):
                 sheet.payment_state = "paid"


### PR DESCRIPTION
Since some other modules can introduce other moves to the expense sheet, this refactor allow some compatibility between those modules without changing behavior on this module.

This the module [hr_expense_employee_payment](https://github.com/OCA/hr-expense/pull/321) allows to create more journal items in expense sheet, a mapped has been added to maintain consistance and don't break things.

MT-12694 @moduon @rafaelbn @yajo @kittiu please review if you want 😄 