### PR TITLE
[15.0][FIX] Clear price_tax when the Taxes field is empty

### DIFF
--- a/hr_expense_tax_adjust/models/hr_expense.py
+++ b/hr_expense_tax_adjust/models/hr_expense.py
@@ -32,9 +32,13 @@ class HrExpense(models.Model):
 
     @api.depends("currency_id", "tax_ids", "total_amount", "unit_amount", "quantity")
     def _compute_amount_price_tax(self):
-        for expense in self.filtered(lambda l: not l.tax_adjust):
-            price_tax = expense._get_expense_price_tax()
-            expense.price_tax = price_tax
+        for expense in self:
+            if not expense.tax_ids:
+                expense.price_tax = 0.0
+                continue
+
+            if not expense.tax_adjust:
+                expense.price_tax = expense._get_expense_price_tax()
 
     @api.onchange("price_tax", "tax_ids", "total_amount", "unit_amount", "quantity")
     def _onchange_price_tax(self):


### PR DESCRIPTION
I found an error when creating a journal entry for an expense without taxes while the price_tax field still has a value. On the UI, the price_tax field is hidden, so the issue is not visible to the user until the journal entry is created

This PR resets price_tax to 0 when no taxes are set.

**Steps to reproduce**
 1. Create an Expense Report and add an expense line with taxes (Example: amount = 100, taxes = 7%, price_tax = 7)
 2. Remove the 7% tax and save the expense sheet. The price_tax value remains 7 (it is not cleared to zero)
 3. Submit the expense sheet to create the journal entry. The system throws an error due to a tax difference, as shown in the screenshot below.
 
<img width="1388" height="276" alt="image" src="https://github.com/user-attachments/assets/92bbf592-21fd-4a65-9cf6-35d1da97f2d7" />

@Saran440, Please consider reviewing and approving this PR.