### PR TITLE
[18.0][IMP] hr_expense_tier_validation: clear review_ids when reset draft & exception expense

### DIFF
--- a/hr_expense_tier_validation/README.rst
+++ b/hr_expense_tier_validation/README.rst
@@ -42,14 +42,26 @@ Configuration
 To configure tier validation for HR expenses:
 
 1. Go to *Settings > Technical > Tier Validations > Tier Definition*
-2. Create the desired approval tiers for the hr.expense model.
+2. Set the model to **Expense Report** (``hr.expense.sheet``).
+3. Create the desired approval tiers with the appropriate conditions.
 
-To define exceptions for expense approvals:
+To define exception fields that can still be edited while the expense is
+under or after tier validation:
 
-1. Go to *Settings > Technical > System Parameters*
-2. Search for "hr_expense.tier_exceptions" in the system parameters.
-3. Add the necessary fields that should be excluded from tier
-   validation.
+1. Go to *Settings > Technical > Tier Validations > Tier Validation
+   Exceptions*
+2. Create a new exception for model **Expense Report**
+   (``hr.expense.sheet``) or **Expense** (``hr.expense``):
+
+   - **Under Validation** — fields allowed to be modified while the
+     expense sheet is in *Submitted* state and awaiting tier approval.
+     Set *Allowed to Write Under Validation*.
+   - **After Validation** — fields allowed to be modified after the
+     expense sheet is fully approved (*Approved*, *Posted*, *Done*). Set
+     *Allowed to Write After Validation*.
+
+3. Optionally restrict the exception to specific user groups.
+4. Add the field(s) you want to allow editing.
 
 Usage
 =====

--- a/hr_expense_tier_validation/__manifest__.py
+++ b/hr_expense_tier_validation/__manifest__.py
@@ -9,7 +9,7 @@
     "license": "AGPL-3",
     "website": "https://github.com/OCA/hr-expense",
     "depends": ["hr_expense", "base_tier_validation"],
-    "data": ["data/ir_config_parameter.xml", "views/hr_expense_sheet_view.xml"],
+    "data": ["views/hr_expense_sheet_view.xml"],
     "installable": True,
     "maintainers": ["ps-tubtim"],
 }

--- a/hr_expense_tier_validation/data/ir_config_parameter.xml
+++ b/hr_expense_tier_validation/data/ir_config_parameter.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8" ?>
-<odoo noupdate="1">
-    <record id="parameter_expense_validation_exceptions" model="ir.config_parameter">
-        <field name="key">hr_expense.tier_exceptions</field>
-        <field name="value">["message_follower_ids", "access_token"]</field>
-    </record>
-</odoo>

--- a/hr_expense_tier_validation/models/__init__.py
+++ b/hr_expense_tier_validation/models/__init__.py
@@ -3,3 +3,4 @@
 from . import hr_expense_sheet
 from . import hr_expense
 from . import tier_definition
+from . import tier_validation_exception

--- a/hr_expense_tier_validation/models/hr_expense.py
+++ b/hr_expense_tier_validation/models/hr_expense.py
@@ -1,48 +1,104 @@
 # Copyright 2022 Ecosoft Co., Ltd. (http://ecosoft.co.th)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-import ast
-
-from odoo import _, api, models
+from odoo import models
 from odoo.exceptions import ValidationError
+
+BASE_EXCEPTION_FIELDS = [
+    "message_follower_ids",
+    "access_token",
+    "message_main_attachment_id",
+    "accounting_date",
+]
 
 
 class HrExpense(models.Model):
     _inherit = "hr.expense"
 
-    @api.model
-    def _get_under_validation_exceptions(self):
-        """Extend for more field exceptions."""
-        params_exception = (
-            self.env["ir.config_parameter"]
+    def _get_exception_fields(self, extra_domain=None):
+        company = self.company_id or self.sheet_id.company_id or self.env.company
+        return (
+            self.env["tier.validation.exception"]
             .sudo()
-            .get_param("hr_expense.tier_exceptions")
-            or []
+            .search(
+                [
+                    ("model_name", "=", "hr.expense"),
+                    ("company_id", "in", [False] + company.ids),
+                    "|",
+                    ("group_ids", "in", self.env.user.groups_id.ids),
+                    ("group_ids", "=", False),
+                    *(extra_domain or []),
+                ]
+            )
+            .mapped("field_ids.name")
         )
-        # Convert to list
-        if not isinstance(params_exception, list):
-            params_exception = ast.literal_eval(params_exception)
-        return params_exception
 
-    def _check_allow_write_under_validation(self, vals):
-        """Allow to add exceptions for fields that are allowed to be written
-        or for reviewers for all fields, even when the record is under
-        validation."""
-        exceptions = self._get_under_validation_exceptions()
-        for val in vals:
-            if val not in exceptions:
-                return False
-        return True
+    def _get_validation_exceptions(self, extra_domain=None):
+        exception_fields = self._get_exception_fields(extra_domain=extra_domain)
+        return list(set(exception_fields + BASE_EXCEPTION_FIELDS))
+
+    def _get_under_validation_exceptions(self):
+        return self._get_validation_exceptions(
+            extra_domain=[("allowed_to_write_under_validation", "=", True)]
+        )
+
+    def _get_after_validation_exceptions(self):
+        return self._get_validation_exceptions(
+            extra_domain=[("allowed_to_write_after_validation", "=", True)]
+        )
+
+    def _get_fields_to_write_validation(self, vals, records_exception_function):
+        exceptions = records_exception_function()
+        not_allowed_fields = [val for val in vals if val not in exceptions]
+
+        not_allowed_field_names = []
+        allowed_field_names = []
+        for fld_name, fld_data in self.fields_get(
+            not_allowed_fields + exceptions
+        ).items():
+            if fld_name in not_allowed_fields:
+                not_allowed_field_names.append(fld_data["string"])
+            else:
+                allowed_field_names.append(fld_data["string"])
+        return allowed_field_names, not_allowed_field_names
+
+    def _get_sheet_validation_write_check(self):
+        self.ensure_one()
+        sheet = self.sheet_id
+        if sheet.state == "submit":
+            return "under", self._get_under_validation_exceptions
+        if sheet.state in ("approve", "post", "done"):
+            return "after", self._get_after_validation_exceptions
+        return False, False
 
     def write(self, vals):
         for rec in self:
             sheet = rec.sheet_id
             if (
-                sheet.state == "submit"
+                sheet.state in ("submit", "approve", "post", "done")
                 and sheet.review_ids
-                and not sheet.validated
                 and not sheet.rejected
-                and not rec._check_allow_write_under_validation(vals)
+                and not rec.env.context.get("skip_validation_check")
             ):
-                raise ValidationError(_("The expense report is under validation."))
+                validation_step, exception_function = (
+                    rec._get_sheet_validation_write_check()
+                )
+                if not exception_function:
+                    continue
+                allowed_fields, not_allowed_fields = (
+                    rec._get_fields_to_write_validation(vals, exception_function)
+                )
+                if not_allowed_fields:
+                    raise ValidationError(
+                        self.env._(
+                            "You are not allowed to write those fields "
+                            "%(validation_step)s validation.\n"
+                            "- %(not_allowed_fields_str)s\n\n"
+                            "Only those fields can be modified:\n"
+                            "- %(allowed_fields_str)s",
+                            validation_step=validation_step,
+                            not_allowed_fields_str="\n- ".join(not_allowed_fields),
+                            allowed_fields_str="\n- ".join(allowed_fields),
+                        )
+                    )
         return super().write(vals)

--- a/hr_expense_tier_validation/models/hr_expense_sheet.py
+++ b/hr_expense_tier_validation/models/hr_expense_sheet.py
@@ -1,7 +1,7 @@
 # Copyright 2019 Ecosoft Co., Ltd. (http://ecosoft.co.th)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import models
+from odoo import api, models
 
 
 class HrExpenseSheet(models.Model):
@@ -13,3 +13,22 @@ class HrExpenseSheet(models.Model):
     _state_to = ["approve", "post", "done"]
 
     _tier_validation_manual_config = False
+
+    def _allow_to_remove_reviews(self, values):
+        self.ensure_one()
+        res = super()._allow_to_remove_reviews(values)
+        # Reset to draft, approval_state is set to False
+        if self._name == "hr.expense.sheet" and self._state_field in values:
+            state_to = values[self._state_field]
+            if not state_to:
+                return True
+        return res
+
+    @api.model
+    def _get_validation_exceptions(self, extra_domain=None, add_base_exceptions=True):
+        res = super()._get_validation_exceptions(
+            extra_domain=extra_domain, add_base_exceptions=add_base_exceptions
+        )
+        if add_base_exceptions:
+            res.append("accounting_date")
+        return list(set(res))

--- a/hr_expense_tier_validation/models/tier_validation_exception.py
+++ b/hr_expense_tier_validation/models/tier_validation_exception.py
@@ -1,0 +1,13 @@
+# Copyright 2026 Ecosoft Co., Ltd. (http://ecosoft.co.th)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import api, models
+
+
+class TierValidationException(models.Model):
+    _inherit = "tier.validation.exception"
+
+    @api.model
+    def _get_tier_validation_model_names(self):
+        res = super()._get_tier_validation_model_names()
+        return res + ["hr.expense"]

--- a/hr_expense_tier_validation/readme/CONFIGURE.md
+++ b/hr_expense_tier_validation/readme/CONFIGURE.md
@@ -1,10 +1,14 @@
 To configure tier validation for HR expenses:
 
 1. Go to *Settings > Technical > Tier Validations > Tier Definition*
-2. Create the desired approval tiers for the hr.expense model.
+2. Set the model to **Expense Report** (`hr.expense.sheet`).
+3. Create the desired approval tiers with the appropriate conditions.
 
-To define exceptions for expense approvals:
+To define exception fields that can still be edited while the expense is under or after tier validation:
 
-1. Go to *Settings > Technical > System Parameters*
-2. Search for "hr_expense.tier_exceptions" in the system parameters.
-3. Add the necessary fields that should be excluded from tier validation.
+1. Go to *Settings > Technical > Tier Validations > Tier Validation Exceptions*
+2. Create a new exception for model **Expense Report** (`hr.expense.sheet`) or **Expense** (`hr.expense`):
+   - **Under Validation** — fields allowed to be modified while the expense sheet is in *Submitted* state and awaiting tier approval. Set *Allowed to Write Under Validation*.
+   - **After Validation** — fields allowed to be modified after the expense sheet is fully approved (*Approved*, *Posted*, *Done*). Set *Allowed to Write After Validation*.
+3. Optionally restrict the exception to specific user groups.
+4. Add the field(s) you want to allow editing.

--- a/hr_expense_tier_validation/static/description/index.html
+++ b/hr_expense_tier_validation/static/description/index.html
@@ -391,14 +391,26 @@ tier validation process.</p>
 <p>To configure tier validation for HR expenses:</p>
 <ol class="arabic simple">
 <li>Go to <em>Settings &gt; Technical &gt; Tier Validations &gt; Tier Definition</em></li>
-<li>Create the desired approval tiers for the hr.expense model.</li>
+<li>Set the model to <strong>Expense Report</strong> (<tt class="docutils literal">hr.expense.sheet</tt>).</li>
+<li>Create the desired approval tiers with the appropriate conditions.</li>
 </ol>
-<p>To define exceptions for expense approvals:</p>
+<p>To define exception fields that can still be edited while the expense is
+under or after tier validation:</p>
 <ol class="arabic simple">
-<li>Go to <em>Settings &gt; Technical &gt; System Parameters</em></li>
-<li>Search for “hr_expense.tier_exceptions” in the system parameters.</li>
-<li>Add the necessary fields that should be excluded from tier
-validation.</li>
+<li>Go to <em>Settings &gt; Technical &gt; Tier Validations &gt; Tier Validation
+Exceptions</em></li>
+<li>Create a new exception for model <strong>Expense Report</strong>
+(<tt class="docutils literal">hr.expense.sheet</tt>) or <strong>Expense</strong> (<tt class="docutils literal">hr.expense</tt>):<ul>
+<li><strong>Under Validation</strong> — fields allowed to be modified while the
+expense sheet is in <em>Submitted</em> state and awaiting tier approval.
+Set <em>Allowed to Write Under Validation</em>.</li>
+<li><strong>After Validation</strong> — fields allowed to be modified after the
+expense sheet is fully approved (<em>Approved</em>, <em>Posted</em>, <em>Done</em>). Set
+<em>Allowed to Write After Validation</em>.</li>
+</ul>
+</li>
+<li>Optionally restrict the exception to specific user groups.</li>
+<li>Add the field(s) you want to allow editing.</li>
 </ol>
 </div>
 <div class="section" id="usage">

--- a/hr_expense_tier_validation/tests/test_hr_expense_tier_validation.py
+++ b/hr_expense_tier_validation/tests/test_hr_expense_tier_validation.py
@@ -73,11 +73,40 @@ class TestHrExpenseTierValidation(TestExpenseCommon):
             with Form(expense) as exp:
                 exp.name = "Change name"
         # test change field exception in tier, it should allow edit
-        self.env["ir.config_parameter"].sudo().set_param(
-            "hr_expense.tier_exceptions", "['name']"
+        field_name = self.env["ir.model.fields"].search(
+            [
+                ("model", "=", "hr.expense"),
+                ("name", "=", "name"),
+            ]
+        )
+        model_expense = self.env["ir.model"].search([("model", "=", "hr.expense")])
+        self.env["tier.validation.exception"].create(
+            {
+                "model_id": model_expense.id,
+                "field_ids": [(6, 0, field_name.ids)],
+                "allowed_to_write_under_validation": True,
+                "allowed_to_write_after_validation": False,
+            }
         )
         with Form(expense) as exp:
             exp.name = "Change name"
 
         message = expense._message_subscribe(self.partner_a.ids)
         self.assertTrue(message, True)
+
+        # test approve expense sheets after validation is approved
+        sheet.with_user(self.expense_user_manager).validate_tier()
+        self.assertTrue(sheet.validated)
+        sheet.with_user(self.expense_user_manager).action_approve_expense_sheets()
+        self.assertEqual(sheet.state, "approve")
+        with self.assertRaises(ValidationError):
+            expense.write({"name": "Change name after approval"})
+        self.env["tier.validation.exception"].create(
+            {
+                "model_id": model_expense.id,
+                "field_ids": [(6, 0, field_name.ids)],
+                "allowed_to_write_under_validation": False,
+                "allowed_to_write_after_validation": True,
+            }
+        )
+        expense.write({"name": "Change name after approval"})


### PR DESCRIPTION
This PR fixed & implement in `hr_expense_tier_validation`

### 1. Approve expense sheet and Reset to Draft

**Step to reproduce:**

1. Create tier validation with hr.expense.sheet
2. Create expense and approve (with Tier)
3. Reset to draft expense, state change to To Submit but user can't editable name
    
<img width="2524" height="1183" alt="selection_290" src="https://github.com/user-attachments/assets/7095d366-9ba7-49da-8778-417c181cc505" />


### 2. Tier Validation Exception on `hr.expense`

This case improved to use standard, because new version base_tier_validation has `Tier Validation Exception`. So, we change exception from hard code to config following standard

**Changes:**
- Add exception config on `hr.expense`
- After validated, `hr.expense` is read-only unless exception is configured

<img width="1631" height="618" alt="selection_291" src="https://github.com/user-attachments/assets/7eb73fa7-ab4f-4450-91c5-2a6c260cffd3" />