### PR TITLE
[18.0][FIX] hr_expense_petty_cash: permission user error

### DIFF
--- a/hr_expense_petty_cash/models/hr_expense_sheet.py
+++ b/hr_expense_petty_cash/models/hr_expense_sheet.py
@@ -44,7 +44,7 @@ class HrExpenseSheet(models.Model):
     def _check_petty_cash_amount(self):
         for rec in self:
             if rec.payment_mode == "petty_cash":
-                petty_cash = rec.petty_cash_id
+                petty_cash = rec.petty_cash_id.sudo()
                 balance = petty_cash.petty_cash_balance
                 amount = rec.total_amount
                 company_currency = rec.company_id.currency_id

--- a/hr_expense_petty_cash/security/ir.model.access.csv
+++ b/hr_expense_petty_cash/security/ir.model.access.csv
@@ -1,2 +1,3 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_hr_expense_petty_cash,access_hr_expense_petty_cash,model_petty_cash,account.group_account_user,1,1,1,1
+access_hr_expense_petty_cash_user,access_hr_expense_petty_cash_user,model_petty_cash,base.group_user,1,0,0,0


### PR DESCRIPTION
User without accounting permission can't select petty cash holder.
because `ir.model.access.csv` deleted on v18 https://github.com/OCA/hr-expense/commit/133960916bbbc471ba9096d01c021f346ef318c8#diff-1a02eaacedcbb4eec7cd0ef260b5774c5593884be86a612c532bb095f66861dcL3

Step to reproduce:
1. Create petty cash
2. Login user without permission accounting
3. Create new expense with petty cash, when select petty cash it will error permission
<img width="742" height="320" alt="Screenshot 2026-06-18 180635" src="https://github.com/user-attachments/assets/b7532654-01d4-49d5-a370-b25058031955" />
