### PR TITLE
[18.0][FIX] hr_expense_advance_clearing: clearing reset draft mistake

### DIFF
--- a/hr_expense_advance_clearing/models/account_move.py
+++ b/hr_expense_advance_clearing/models/account_move.py
@@ -24,8 +24,20 @@ class AccountMove(models.Model):
             )
 
     def button_draft(self):
+        if self.env.context.get("skip_invoice_sync"):
+            return super().button_draft()
         self._check_hr_advance_move_reconciled()
-        return super().button_draft()
+        # Clearing entries keep an explicit balance + explicit tax lines. The
+        # tax recompute done by the sync when resetting to draft would otherwise
+        # strip the tax twice and create a spurious "Automatic Balancing Line".
+        clearing_moves = self.filtered(
+            lambda m: m.move_type == "entry" and m.expense_sheet_id.advance_sheet_id
+        )
+        if not clearing_moves:
+            return super().button_draft()
+
+        (self - clearing_moves).button_draft()
+        return clearing_moves.with_context(skip_invoice_sync=True).button_draft()
 
     def button_cancel(self):
         self._check_hr_advance_move_reconciled()

--- a/hr_expense_advance_clearing/tests/test_hr_expense_advance_clearing.py
+++ b/hr_expense_advance_clearing/tests/test_hr_expense_advance_clearing.py
@@ -315,3 +315,61 @@ class TestHrExpenseAdvanceClearing(TestExpenseCommon):
             cancel=True,
         )
         self.assertNotEqual(reverse_move, self.advance.account_move_ids)
+
+    @mute_logger("odoo.models.unlink")
+    def test_5_clearing_move_reset_draft_tax_excluded(self):
+        """Resetting a clearing entry with a tax-excluded tax to draft must not
+        add auto lines."""
+        # ------------------ Advance --------------------------
+        self.advance.action_submit_sheet()
+        self.advance.action_approve_expense_sheets()
+        self.advance.action_sheet_move_post()
+        self.assertEqual(self.advance.clearing_residual, 1000.0)
+        self._register_payment(self.advance.account_move_ids, 1000.0)
+        self.assertEqual(self.advance.state, "done")
+        # ------------------ Clearing, Return Advance --------------------------
+        # Clear this with previous advance
+        self.clearing_less.advance_sheet_id = self.advance
+        self.clearing_less.expense_line_ids.tax_ids = self.tax_purchase_a
+        self.clearing_less.action_submit_sheet()
+        self.clearing_less.action_approve_expense_sheets()
+        self.clearing_less.action_sheet_move_post()
+
+        clearing_move = self.clearing_less.account_move_ids
+        self.assertEqual(clearing_move.state, "posted")
+        lines_before = clearing_move.line_ids
+        clearing_move.button_draft()
+        lines_after = clearing_move.line_ids
+        self.assertEqual(len(lines_after), len(lines_before))
+        self.assertAlmostEqual(sum(lines_after.mapped("balance")), 0.0)
+
+    @mute_logger("odoo.models.unlink")
+    def test_6_clearing_move_reset_draft_tax_included(self):
+        """Resetting a clearing entry with a tax-excluded tax to draft must not
+        add auto lines."""
+        # ------------------ Advance --------------------------
+        self.advance.action_submit_sheet()
+        self.advance.action_approve_expense_sheets()
+        self.advance.action_sheet_move_post()
+        self.assertEqual(self.advance.clearing_residual, 1000.0)
+        self._register_payment(self.advance.account_move_ids, 1000.0)
+        self.assertEqual(self.advance.state, "done")
+        # ------------------ Clearing, Return Advance --------------------------
+        # Clear this with previous advance
+        self.clearing_less.advance_sheet_id = self.advance
+
+        tax_included = self.tax_purchase_a.copy(
+            {"name": "test: tax purchase include", "price_include": True}
+        )
+        self.clearing_less.expense_line_ids.tax_ids = tax_included
+        self.clearing_less.action_submit_sheet()
+        self.clearing_less.action_approve_expense_sheets()
+        self.clearing_less.action_sheet_move_post()
+
+        clearing_move = self.clearing_less.account_move_ids
+        self.assertEqual(clearing_move.state, "posted")
+        lines_before = clearing_move.line_ids
+        clearing_move.button_draft()
+        lines_after = clearing_move.line_ids
+        self.assertEqual(len(lines_after), len(lines_before))
+        self.assertAlmostEqual(sum(lines_after.mapped("balance")), 0.0)


### PR DESCRIPTION
This PR fixed bug move clearing **with tax** auto create `Automatic Balancing Line` when reset to draft move of clearing

Step to reproduce:
1. Create advance > pay
2. Create clearing **with tax** > submit > approve > post
3. Go to Move of clearing > Reset to Draft
4. It will create new line `Automatic Balancing Line` and deduct amount clearing line
