### PR TITLE
[18.0][FIX] hr_expense_advance_clearing: permission return_count

### DIFF
--- a/hr_expense_advance_clearing/models/hr_expense_sheet.py
+++ b/hr_expense_advance_clearing/models/hr_expense_sheet.py
@@ -38,7 +38,7 @@ class HrExpenseSheet(models.Model):
         readonly=True,
         help="Show reference return advance on advance",
     )
-    return_count = fields.Integer(compute="_compute_return_count")
+    return_count = fields.Integer(compute="_compute_return_count", compute_sudo=True)
     clearing_residual = fields.Monetary(
         string="Amount to clear",
         compute="_compute_clearing_residual",


### PR DESCRIPTION
This PR fixed users expense can't submit expense when install `hr_expense_advance_clearing` because field `return_count` count from `account.payment`

Step to reproduce:
1. install module hr_expense_advance_clearing
2. login with user without accounting
3. create expense > Submit > it will error permission
<img width="1727" height="507" alt="selection_429" src="https://github.com/user-attachments/assets/814746a4-5c8f-4bb9-965f-e01992135bb9" />
