### PR TITLE
[18.0][FIX] hr_expense_advance_clearing: handle draft clearing payments

### DIFF
--- a/hr_expense_advance_clearing/models/account_payment.py
+++ b/hr_expense_advance_clearing/models/account_payment.py
@@ -21,6 +21,29 @@ class AccountPayment(models.Model):
         )
         return super()._synchronize_from_moves(changed_fields)
 
+    def action_post(self):
+        res = super().action_post()
+        for payment in self.filtered("move_id"):
+            clearing_moves = payment.invoice_ids.filtered(
+                lambda move: move.state == "posted"
+                and move.move_type == "entry"
+                and move.expense_sheet_id.advance_sheet_id
+            )
+            if not clearing_moves:
+                continue
+
+            lines = (clearing_moves + payment.move_id).line_ids.filtered(
+                lambda line: line.account_id.reconcile
+                and not line.reconciled
+                and line.account_id.account_type
+                in ("asset_receivable", "liability_payable")
+            )
+            for account in lines.account_id:
+                account_lines = lines.filtered_domain([("account_id", "=", account.id)])
+                if len(account_lines) > 1:
+                    account_lines.reconcile()
+        return res
+
     @api.model
     def _get_valid_payment_account_types(self):
         account_types = super()._get_valid_payment_account_types()

--- a/hr_expense_advance_clearing/tests/test_hr_expense_advance_clearing.py
+++ b/hr_expense_advance_clearing/tests/test_hr_expense_advance_clearing.py
@@ -393,3 +393,46 @@ class TestHrExpenseAdvanceClearing(TestExpenseCommon):
         lines_after = clearing_move.line_ids
         self.assertEqual(len(lines_after), len(lines_before))
         self.assertAlmostEqual(sum(lines_after.mapped("balance")), 0.0)
+
+    @mute_logger("odoo.models.unlink")
+    def test_7_reconcile_clearing_payment_after_reset_to_draft(self):
+        """A reposted excess-clearing payment must be reconciled again."""
+        # Pay an advance of 1,000.
+        self.advance.action_submit_sheet()
+        self.advance.action_approve_expense_sheets()
+        self.advance.action_sheet_move_post()
+        self._register_payment(self.advance.account_move_ids, 1000.0)
+
+        # Clear 1,200 and pay the remaining 200.
+        self.clearing_more.advance_sheet_id = self.advance
+        self.clearing_more.action_submit_sheet()
+        self.clearing_more.action_approve_expense_sheets()
+        self.clearing_more.action_sheet_move_post()
+        clearing_move = self.clearing_more.account_move_ids
+        payments_before = self.env["account.payment"].search([])
+        register_payment = clearing_move.action_force_register_payment()
+        self._register_payment(clearing_move, 200.0, ctx=register_payment["context"])
+        payment = self.env["account.payment"].search([]) - payments_before
+        self.assertEqual(len(payment), 1)
+        # _finalize_clearing_payments() marks the confirmed payment as paid.
+        self.assertEqual(payment.state, "paid")
+
+        payable_lines = (clearing_move + payment.move_id).line_ids.filtered(
+            lambda line: line.account_id.account_type == "liability_payable"
+        )
+        self.assertTrue(payable_lines)
+        self.assertTrue(all(payable_lines.mapped("reconciled")))
+
+        # Resetting the payment removes its reconciliation. Posting it again
+        # must reconcile it back to the excess-clearing journal entry.
+        payment.action_draft()
+        self.assertEqual(payment.state, "draft")
+        self.assertFalse(any(payable_lines.mapped("reconciled")))
+        # _finalize_clearing_payments() must not force a draft payment to paid.
+        self.env["account.payment.register"]._finalize_clearing_payments(payment)
+        self.assertEqual(payment.state, "draft")
+
+        payment.action_post()
+        self.assertNotEqual(payment.state, "draft")
+        self.assertTrue(all(payable_lines.mapped("reconciled")))
+        self.assertEqual(clearing_move.amount_residual, 0.0)

--- a/hr_expense_advance_clearing/wizard/account_payment_register.py
+++ b/hr_expense_advance_clearing/wizard/account_payment_register.py
@@ -10,6 +10,13 @@ from odoo.tools import float_compare
 class AccountPaymentRegister(models.TransientModel):
     _inherit = "account.payment.register"
 
+    def _finalize_clearing_payments(self, payments):
+        """Mark confirmed clearing payments as paid and preserve drafts."""
+        for payment in payments.filtered(
+            lambda payment: payment.state in ("in_process", "paid")
+        ):
+            payment.write({"move_id": payment.move_id.id, "state": "paid"})
+
     def _validate_over_return(self):
         """Actual remaining = amount to clear - clear pending
         and it is not legit to return more than remaining"""
@@ -61,6 +68,5 @@ class AccountPaymentRegister(models.TransientModel):
         """Update the payment state when the clearing amount exceeds the advance."""
         payments = super()._create_payments()
         if self.env.context.get("expense_clearing"):
-            for payment in payments:
-                payment.write({"move_id": payment.move_id.id, "state": "paid"})
+            self._finalize_clearing_payments(payments)
         return payments


### PR DESCRIPTION
This PR fixes an issue where an advance clearing document is not marked as paid after its payment is reset to draft and confirmed again.

Steps to reproduce:
1. Create advance > submit > approve > post > paid
2. Create clearing more than advance > submit > approve > post > paid
3. Open the clearing payment, reset it to draft, and confirm it again.

The clearing document returns to the Posted state and is not marked as Paid.