### PR TITLE
[18.0][IMP] hr_expense_invoice: auto-create vendor bills from vendor

### DIFF
--- a/hr_expense_invoice/README.rst
+++ b/hr_expense_invoice/README.rst
@@ -37,11 +37,13 @@ employee. It allows to set a supplier invoice for each expense line,
 adding the corresponding journal items to transfer the debt to the
 employee.
 
-There are 2 ways to reference expense to invoice.
+There are 3 ways to reference an expense to a vendor bill.
 
-1. On expense, directly select one invoice.
-2. On expense report, use button "Create Vendor Bill" to create one
-   invoice for multiple expenses.
+1. On the expense, select an existing posted vendor bill.
+2. On the expense, select a vendor. The module creates the vendor bill
+   on approval (same as "Create Vendor Bill", with the partner
+   pre-filled) and follows the same accounting path.
+3. On the expense report, use the button "Create Vendor Bill".
 
 **Table of contents**
 
@@ -58,6 +60,15 @@ Usage
   new.
 - Process expense sheet.
 - On paying expense sheet, you are reconciling supplier invoice too.
+
+**Select a vendor and auto-create the vendor bill**
+
+- Create an expense paid by the employee and set the **Vendor**.
+- Submit and approve the expense report. A draft vendor bill is created
+  and linked to the line.
+- Post the expense report. The vendor bill is posted and the payable is
+  transferred to the employee. The company still owes the employee until
+  you register that reimbursement.
 
 **Create one invoice to multiple expenses**
 

--- a/hr_expense_invoice/__manifest__.py
+++ b/hr_expense_invoice/__manifest__.py
@@ -1,5 +1,6 @@
 # Copyright 2015-2021 Tecnativa - Pedro M. Baeza
 # Copyright 2017 Tecnativa - Vicent Cubells
+# Copyright 2026 Gray Matter Logic
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 {

--- a/hr_expense_invoice/i18n/hr_expense_invoice.pot
+++ b/hr_expense_invoice/i18n/hr_expense_invoice.pot
@@ -155,6 +155,20 @@ msgstr ""
 
 #. module: hr_expense_invoice
 #. odoo-python
+#: code:addons/hr_expense_invoice/models/hr_expense.py:0
+msgid "The vendor and the vendor bill partner must be the same."
+msgstr ""
+
+#. module: hr_expense_invoice
+#. odoo-python
+#: code:addons/hr_expense_invoice/models/hr_expense_sheet.py:0
+msgid ""
+"Please set a vendor on the expense or a partner on the "
+"vendor bill before posting the expense report."
+msgstr ""
+
+#. module: hr_expense_invoice
+#. odoo-python
 #: code:addons/hr_expense_invoice/models/hr_expense_sheet.py:0
 msgid "You can only generate an accounting entry for approved expense(s)."
 msgstr ""

--- a/hr_expense_invoice/models/hr_expense.py
+++ b/hr_expense_invoice/models/hr_expense.py
@@ -2,6 +2,7 @@
 # Copyright 2020 Tecnativa - David Vidal
 # Copyright 2021 Tecnativa - Víctor Martínez
 # Copyright 2015-2024 Tecnativa - Pedro M. Baeza
+# Copyright 2026 Gray Matter Logic
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from odoo import Command, api, fields, models
@@ -15,12 +16,13 @@ class HrExpense(models.Model):
     invoice_id = fields.Many2one(
         comodel_name="account.move",
         string="Vendor Bill",
-        domain=[
-            ("move_type", "=", "in_invoice"),
-            ("state", "=", "posted"),
-            ("payment_state", "=", "not_paid"),
-            ("expense_ids", "=", False),
-        ],
+        domain=(
+            "[('move_type', '=', 'in_invoice'),"
+            " ('state', '=', 'posted'),"
+            " ('payment_state', '=', 'not_paid'),"
+            " ('expense_ids', '=', False),"
+            " ('partner_id', '=?', vendor_id)]"
+        ),
         copy=False,
     )
     transfer_move_ids = fields.One2many(
@@ -35,6 +37,7 @@ class HrExpense(models.Model):
     )
 
     def _prepare_invoice_values(self):
+        self.ensure_one()
         invoice_lines = [
             Command.create(
                 {
@@ -50,12 +53,17 @@ class HrExpense(models.Model):
                 }
             )
         ]
-        return {
+        values = {
             "name": "/",
             "move_type": "in_invoice",
             "invoice_date": self.date,
+            "company_id": self.company_id.id,
+            "currency_id": self.currency_id.id,
             "invoice_line_ids": invoice_lines,
         }
+        if self.vendor_id:
+            values["partner_id"] = self.vendor_id.id
+        return values
 
     def _prepare_own_account_transfer_move_vals(self):
         self.ensure_one()
@@ -101,6 +109,7 @@ class HrExpense(models.Model):
         }
 
     def action_expense_create_invoice(self):
+        self.ensure_one()
         invoice = self.env["account.move"].create(self._prepare_invoice_values())
         attachments = self.env["ir.attachment"].search(
             [("res_model", "=", self._name), ("res_id", "in", self.ids)]
@@ -117,6 +126,28 @@ class HrExpense(models.Model):
         )
         return True
 
+    def _sync_vendor_from_invoice(self):
+        """Keep vendor_id aligned with the linked vendor bill partner."""
+        if self.env.context.get("skip_vendor_invoice_sync"):
+            return
+        for expense in self.filtered(lambda rec: rec.invoice_id.partner_id):
+            if expense.vendor_id != expense.invoice_id.partner_id:
+                expense.with_context(skip_vendor_invoice_sync=True).write(
+                    {"vendor_id": expense.invoice_id.partner_id.id}
+                )
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        expenses = super().create(vals_list)
+        expenses._sync_vendor_from_invoice()
+        return expenses
+
+    def write(self, vals):
+        res = super().write(vals)
+        if vals.get("invoice_id"):
+            self._sync_vendor_from_invoice()
+        return res
+
     @api.constrains("invoice_id")
     def _check_invoice_id(self):
         for expense in self:  # Only non binding expense
@@ -126,6 +157,22 @@ class HrExpense(models.Model):
                 and expense.invoice_id.state != "posted"
             ):
                 raise UserError(self.env._("Vendor bill state must be Posted"))
+
+    @api.constrains("invoice_id", "vendor_id")
+    def _check_vendor_matches_invoice(self):
+        for expense in self:
+            partner = expense.invoice_id.partner_id
+            if (
+                expense.invoice_id
+                and expense.vendor_id
+                and partner
+                and partner != expense.vendor_id
+            ):
+                raise UserError(
+                    self.env._(
+                        "The vendor and the vendor bill partner must be the same."
+                    )
+                )
 
     @api.onchange("invoice_id")
     def _onchange_invoice_id(self):
@@ -137,9 +184,22 @@ class HrExpense(models.Model):
             self.name = self.name.split(" | ")[0].strip()
             self.name = "{} | {}".format(self.name or "", self.invoice_id.name)
             self.date = self.invoice_id.date
+            if self.invoice_id.partner_id:
+                self.vendor_id = self.invoice_id.partner_id
             if self.invoice_id.company_id != self.company_id:
                 # for avoiding to trigger dependent computes
                 self.company_id = self.invoice_id.company_id.id
+
+    @api.onchange("vendor_id")
+    def _onchange_vendor_id(self):
+        """Selecting a different vendor drops a mismatched linked bill."""
+        if (
+            self.invoice_id
+            and self.vendor_id
+            and self.invoice_id.partner_id
+            and self.invoice_id.partner_id != self.vendor_id
+        ):
+            self.invoice_id = False
 
     # tax_ids put as dependency for assuring this is computed after setting tax_ids
     @api.depends("invoice_id", "tax_ids")

--- a/hr_expense_invoice/models/hr_expense_sheet.py
+++ b/hr_expense_invoice/models/hr_expense_sheet.py
@@ -1,5 +1,6 @@
 # Copyright 2017 Tecnativa - Vicent Cubells
 # Copyright 2015-2024 Tecnativa - Pedro M. Baeza
+# Copyright 2026 Gray Matter Logic
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from odoo import Command, api, fields, models
@@ -16,6 +17,32 @@ class HrExpenseSheet(models.Model):
         return self.filtered(
             lambda sheet: func(expense.invoice_id for expense in sheet.expense_line_ids)
         )
+
+    def _ensure_invoices_from_vendors(self):
+        """Create a vendor bill when the user only selected a vendor."""
+        for expense in self.expense_line_ids.filtered(
+            lambda exp: exp.vendor_id and not exp.invoice_id
+        ):
+            expense.action_expense_create_invoice()
+
+    def _post_draft_expense_invoices(self):
+        """Post never-posted bills created from a vendor before posting the sheet.
+
+        Bills the user reset to draft are left alone so the existing posted-state
+        validation still applies.
+        """
+        invoices = self.mapped("expense_line_ids.invoice_id").filtered(
+            lambda invoice: invoice.state == "draft" and not invoice.posted_before
+        )
+        if invoices.filtered(lambda invoice: not invoice.partner_id):
+            raise UserError(
+                self.env._(
+                    "Please set a vendor on the expense or a partner on the "
+                    "vendor bill before posting the expense report."
+                )
+            )
+        if invoices:
+            invoices.action_post()
 
     def _do_create_ap_moves(self):
         # Create AP transfer entry for expenses paid by employees
@@ -69,6 +96,8 @@ class HrExpenseSheet(models.Model):
         return all_generated_moves
 
     def action_sheet_move_post(self):
+        self._ensure_invoices_from_vendors()
+        self._post_draft_expense_invoices()
         sheets_with_invoices = self.get_expense_sheets_with_invoices(any)
         sheets_all_invoices = self.get_expense_sheets_with_invoices(all)
         for sheet in sheets_with_invoices:
@@ -226,6 +255,7 @@ class HrExpenseSheet(models.Model):
         return super(HrExpenseSheet, self - sheets_with_invoices)._compute_state()
 
     def _do_approve(self):
+        self._ensure_invoices_from_vendors()
         expense_sheets_with_invoices = self.get_expense_sheets_with_invoices(all)
         own_account_sheets = self.filtered(
             lambda sheet: sheet.payment_mode == "own_account"

--- a/hr_expense_invoice/readme/CONTRIBUTORS.md
+++ b/hr_expense_invoice/readme/CONTRIBUTORS.md
@@ -5,3 +5,5 @@
 - Kitti Upariphutthiphong \<<kittiu@ecosoft.co.th>\>
 - Rattapong Chokmasermkul \<<rattapongc@ecosoft.co.th>\>
 - Saran Lim. \<<saranl@ecosoft.co.th>\>
+- [Gray Matter Logic](https://www.graymatterlogic.com):
+  - Maxime Chambreuil \<<maxime.chambreuil@graymatterlogic.com>\>

--- a/hr_expense_invoice/readme/DESCRIPTION.md
+++ b/hr_expense_invoice/readme/DESCRIPTION.md
@@ -3,8 +3,10 @@ employee. It allows to set a supplier invoice for each expense line,
 adding the corresponding journal items to transfer the debt to the
 employee.
 
-There are 2 ways to reference expense to invoice.
+There are 3 ways to reference an expense to a vendor bill.
 
-1.  On expense, directly select one invoice.
-2.  On expense report, use button "Create Vendor Bill" to create one
-    invoice for multiple expenses.
+1.  On the expense, select an existing posted vendor bill.
+2.  On the expense, select a vendor. The module creates the vendor bill
+    on approval (same as "Create Vendor Bill", with the partner
+    pre-filled) and follows the same accounting path.
+3.  On the expense report, use the button "Create Vendor Bill".

--- a/hr_expense_invoice/readme/USAGE.md
+++ b/hr_expense_invoice/readme/USAGE.md
@@ -6,6 +6,15 @@
 - Process expense sheet.
 - On paying expense sheet, you are reconciling supplier invoice too.
 
+**Select a vendor and auto-create the vendor bill**
+
+- Create an expense paid by the employee and set the **Vendor**.
+- Submit and approve the expense report. A draft vendor bill is created
+  and linked to the line.
+- Post the expense report. The vendor bill is posted and the payable is
+  transferred to the employee. The company still owes the employee until
+  you register that reimbursement.
+
 **Create one invoice to multiple expenses**
 
 - Create an expense sheet with one or multiple expense lines

--- a/hr_expense_invoice/tests/test_hr_expense_invoice.py
+++ b/hr_expense_invoice/tests/test_hr_expense_invoice.py
@@ -1,6 +1,7 @@
 # Copyright 2017 Tecnativa - Vicent Cubells
 # Copyright 2021 Tecnativa - Pedro M. Baeza
 # Copyright 2021-2023 Tecnativa - Víctor Martínez
+# Copyright 2026 Gray Matter Logic
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 import base64
 
@@ -320,3 +321,103 @@ class TestHrExpenseInvoice(TestExpenseCommon):
         )
         sheet.account_move_ids |= dummy_move
         sheet._reconcile_ap_moves()
+
+    def test_8_create_invoice_prefills_vendor(self):
+        self.expense.vendor_id = self.partner_a
+        self._action_submit_expenses(self.expense)
+        self.expense.action_expense_create_invoice()
+        self.assertEqual(self.expense.invoice_id.partner_id, self.partner_a)
+        self.assertEqual(self.expense.vendor_id, self.partner_a)
+
+    def test_9_invoice_syncs_vendor(self):
+        self.invoice.action_post()
+        self.expense.invoice_id = self.invoice
+        self.assertEqual(self.expense.vendor_id, self.invoice.partner_id)
+
+    def test_10_vendor_mismatch_raises(self):
+        self.invoice.action_post()
+        self.expense.invoice_id = self.invoice
+        other_vendor = self.env["res.partner"].create({"name": "Other vendor"})
+        with self.assertRaises(UserError):
+            self.expense.vendor_id = other_vendor
+
+    def test_11_vendor_only_own_account_flow(self):
+        self.expense.write(
+            {
+                "vendor_id": self.partner_a.id,
+                "price_unit": 100,
+                "payment_mode": "own_account",
+            }
+        )
+        sheet = self._action_submit_expenses(self.expense)
+        sheet.action_submit_sheet()
+        sheet.action_approve_expense_sheets()
+        self.assertTrue(self.expense.invoice_id)
+        self.assertEqual(self.expense.invoice_id.partner_id, self.partner_a)
+        self.assertEqual(self.expense.invoice_id.state, "draft")
+        self.assertEqual(sheet.invoice_count, 1)
+        self.assertFalse(sheet.account_move_ids)
+        sheet.action_sheet_move_post()
+        self.assertEqual(self.expense.invoice_id.state, "posted")
+        self.assertEqual(self.expense.invoice_id.payment_state, "paid")
+        self.assertEqual(sheet.state, "post")
+        self.assertEqual(sheet.payment_state, "not_paid")
+        self.assertTrue(self.expense.transfer_move_ids)
+        self.assertFalse(
+            self.env["account.payment"].search(
+                [("reconciled_invoice_ids", "in", self.expense.invoice_id.ids)]
+            )
+        )
+
+    def test_12_post_draft_bill_without_partner_raises(self):
+        sheet = self._action_submit_expenses(self.expense)
+        self.expense.action_expense_create_invoice()
+        self.assertFalse(self.expense.invoice_id.partner_id)
+        sheet.action_submit_sheet()
+        sheet.action_approve_expense_sheets()
+        with self.assertRaises(UserError):
+            sheet.action_sheet_move_post()
+
+    def test_13_mixed_vendor_and_invoice(self):
+        self.expense.write({"vendor_id": self.partner_a.id, "price_unit": 100})
+        self.expense2.price_unit = 100
+        self.invoice.action_post()
+        self.expense2.invoice_id = self.invoice
+        sheet = self._action_submit_expenses(self.expense + self.expense2)
+        sheet.action_submit_sheet()
+        sheet.action_approve_expense_sheets()
+        self.assertTrue(self.expense.invoice_id)
+        self.assertEqual(self.expense2.invoice_id, self.invoice)
+        sheet.action_sheet_move_post()
+        self.assertEqual(sheet.state, "post")
+        self.assertEqual(self.expense.invoice_id.payment_state, "paid")
+        self.assertEqual(self.invoice.payment_state, "paid")
+
+    def test_14_onchange_vendor_clears_mismatched_invoice(self):
+        self.invoice.action_post()
+        self._action_submit_expenses(self.expense)
+        other_vendor = self.env["res.partner"].create({"name": "Other vendor"})
+        with Form(self.expense) as expense_form:
+            expense_form.invoice_id = self.invoice
+            self.assertEqual(expense_form.vendor_id, self.invoice.partner_id)
+            expense_form.vendor_id = other_vendor
+            self.assertFalse(expense_form.invoice_id)
+
+    def test_15_onchange_invoice_without_partner(self):
+        self._action_submit_expenses(self.expense)
+        draft_bill = self.env["account.move"].create({"move_type": "in_invoice"})
+        self.expense.invoice_id = draft_bill
+        self.expense._onchange_invoice_id()
+        self.assertFalse(self.expense.vendor_id)
+
+    def test_16_skip_vendor_invoice_sync(self):
+        self.invoice.action_post()
+        self.expense.with_context(
+            skip_vendor_invoice_sync=True
+        )._sync_vendor_from_invoice()
+        self.assertFalse(self.expense.vendor_id)
+        self.expense.with_context(skip_vendor_invoice_sync=True).write(
+            {"invoice_id": self.invoice.id}
+        )
+        self.assertEqual(self.expense.invoice_id, self.invoice)
+        self.assertFalse(self.expense.vendor_id)

--- a/hr_expense_invoice/views/hr_expense_views.xml
+++ b/hr_expense_invoice/views/hr_expense_views.xml
@@ -58,15 +58,24 @@
             >
                 <attribute name="readonly" add="invoice_id" separator=" or " />
             </xpath>
+            <xpath expr="//field[@name='vendor_id']" position="attributes">
+                <attribute name="invisible">0</attribute>
+            </xpath>
             <xpath expr='//field[@name="product_id"]/parent::div' position="after">
                 <!-- Added double, one as invisible and w/o group, for those without the permission -->
                 <field name="invoice_id" invisible="1" />
                 <field
                     name="invoice_id"
                     groups="account.group_account_readonly"
+                    domain="[('move_type', '=', 'in_invoice'),
+                            ('state', '=', 'posted'),
+                            ('payment_state', '=', 'not_paid'),
+                            ('expense_ids', '=', False),
+                            ('partner_id', '=?', vendor_id)]"
                     context="{'default_type': 'in_invoice',
                             'type': 'in_invoice',
                             'journal_type': 'purchase',
+                            'default_partner_id': vendor_id,
                             'default_invoice_date': date,
                             'default_line_ids': [{'product_id': product_id,
                                                           'name': name,
@@ -87,6 +96,13 @@
         <field name="model">hr.expense.sheet</field>
         <field name="inherit_id" ref="hr_expense.view_hr_expense_sheet_form" />
         <field name="arch" type="xml">
+            <xpath
+                expr="//field[@name='expense_line_ids']/list/field[@name='vendor_id']"
+                position="attributes"
+            >
+                <attribute name="column_invisible">0</attribute>
+                <attribute name="optional">show</attribute>
+            </xpath>
             <xpath
                 expr="//field[@name='expense_line_ids']/list/field[@name='name']"
                 position="after"


### PR DESCRIPTION
## Summary

Follow-up to #367, as requested by @pedrobaeza: keep a single module and combine both inputs on `hr_expense_invoice`.

- If **Vendor Bill** (`invoice_id`) is set, keep the current link + AP-transfer behavior.
- If only **Vendor** (`vendor_id`) is set, auto-create the vendor bill on approval (same as the existing Create Vendor Bill button, with the partner pre-filled) and then follow that same path.

This does **not** register bank payments, create a second employee reimbursement bill, or mark the sheet `done`. The company still owes the employee until that reimbursement is registered.

Vendor is shown for employee-paid expenses (it was already on the form, hidden unless paid by company). Vendor and bill partner are kept in sync; a mismatch raises a validation error. Draft bills created this way (or via Create Vendor Bill) are posted when the expense report is posted, and still require a partner.

## Related

- https://github.com/OCA/hr-expense/pull/367
- https://github.com/OCA/l10n-mexico/pull/78

## Test plan

- [ ] Install `hr_expense_invoice` on Odoo 18.0
- [ ] Link an existing posted vendor bill on an expense, approve and post: transfer move is created, vendor bill is reconciled, sheet stays in `post` until the employee is reimbursed
- [ ] Create an employee-paid expense with only a **Vendor**, submit and approve: a draft vendor bill is created and linked
- [ ] Post that report: the bill is posted, payable is transferred to the employee, no bank payment is created, sheet is `post` not `done`
- [ ] Use **Create Vendor Bill** with a vendor already set: the new bill partner is the vendor
- [ ] Mixed report (one line with a vendor, one with an existing bill): both paths work
- [ ] Post a report whose draft bill has no partner: user error asking for a vendor/partner
- [ ] Run `hr_expense_invoice` tests